### PR TITLE
Support of custom db property names for all links

### DIFF
--- a/src/main/kotlin/kotlinx.dnq/LinkDelegates.kt
+++ b/src/main/kotlin/kotlinx.dnq/LinkDelegates.kt
@@ -54,9 +54,10 @@ fun <R : XdEntity, T : XdEntity> xdLink1_N(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink0_1(
         oppositeLink: KProperty1<T, R?>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdOneToOneOptionalLink<R, T> {
-    return XdOneToOneOptionalLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete)
+    return XdOneToOneOptionalLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete)
 }
 
 /**
@@ -64,9 +65,10 @@ inline fun <R : XdEntity, reified T : XdEntity> xdLink0_1(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink1(
         oppositeLink: KProperty1<T, R?>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdOneToOneRequiredLink<R, T> {
-    return XdOneToOneRequiredLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete)
+    return XdOneToOneRequiredLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete)
 }
 
 /**
@@ -74,9 +76,10 @@ inline fun <R : XdEntity, reified T : XdEntity> xdLink1(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink0_N(
         oppositeLink: KProperty1<T, R?>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdOneToManyLink<R, T> {
-    return XdOneToManyLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete, required = false)
+    return XdOneToManyLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete, required = false)
 }
 
 /**
@@ -84,9 +87,10 @@ inline fun <R : XdEntity, reified T : XdEntity> xdLink0_N(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink1_N(
         oppositeLink: KProperty1<T, R?>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdOneToManyLink<R, T> {
-    return XdOneToManyLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete, required = true)
+    return XdOneToManyLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete, required = true)
 }
 
 /**
@@ -94,9 +98,10 @@ inline fun <R : XdEntity, reified T : XdEntity> xdLink1_N(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink0_1(
         oppositeLink: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdManyToOneOptionalLink<R, T> {
-    return XdManyToOneOptionalLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete)
+    return XdManyToOneOptionalLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete)
 }
 
 /**
@@ -104,9 +109,10 @@ inline fun <R : XdEntity, reified T : XdEntity> xdLink0_1(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink1(
         oppositeLink: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdManyToOneRequiredLink<R, T> {
-    return XdManyToOneRequiredLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete)
+    return XdManyToOneRequiredLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete)
 }
 
 /**
@@ -114,9 +120,10 @@ inline fun <R : XdEntity, reified T : XdEntity> xdLink1(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink0_N(
         oppositeLink: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdManyToManyLink<R, T> {
-    return XdManyToManyLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete, required = false)
+    return XdManyToManyLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete, required = false)
 }
 
 /**
@@ -124,67 +131,68 @@ inline fun <R : XdEntity, reified T : XdEntity> xdLink0_N(
  */
 inline fun <R : XdEntity, reified T : XdEntity> xdLink1_N(
         oppositeLink: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String? = null,
         onDelete: OnDeletePolicy = OnDeletePolicy.FAIL,
         onTargetDelete: OnDeletePolicy = OnDeletePolicy.FAIL): XdManyToManyLink<R, T> {
-    return XdManyToManyLink(entityTypeCompanion(), oppositeLink, onDelete, onTargetDelete, required = true)
+    return XdManyToManyLink(entityTypeCompanion(), oppositeLink, dbPropertyName, onDelete, onTargetDelete, required = true)
 }
 
 /**
  * Parent end [0..1] of aggregation association
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdChild0_1(oppositeLink: KProperty1<T, R?>): XdParentToOneOptionalChildLink<R, T> {
-    return XdParentToOneOptionalChildLink(entityTypeCompanion(), oppositeLink)
+inline fun <R : XdEntity, reified T : XdEntity> xdChild0_1(oppositeLink: KProperty1<T, R?>, dbPropertyName: String? = null): XdParentToOneOptionalChildLink<R, T> {
+    return XdParentToOneOptionalChildLink(entityTypeCompanion(), oppositeLink, dbPropertyName)
 }
 
 /**
  * Parent end [1] of aggregation association
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdChild1(oppositeLink: KProperty1<T, R?>): XdParentToOneRequiredChildLink<R, T> {
-    return XdParentToOneRequiredChildLink(entityTypeCompanion(), oppositeLink)
+inline fun <R : XdEntity, reified T : XdEntity> xdChild1(oppositeLink: KProperty1<T, R?>, dbPropertyName: String? = null): XdParentToOneRequiredChildLink<R, T> {
+    return XdParentToOneRequiredChildLink(entityTypeCompanion(), oppositeLink, dbPropertyName)
 }
 
 /**
  * Parent end [0..N] of aggregation association
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdChildren0_N(oppositeLink: KProperty1<T, R?>): XdParentToManyChildrenLink<R, T> {
-    return XdParentToManyChildrenLink(entityTypeCompanion(), oppositeLink, required = false)
+inline fun <R : XdEntity, reified T : XdEntity> xdChildren0_N(oppositeLink: KProperty1<T, R?>, dbPropertyName: String? = null): XdParentToManyChildrenLink<R, T> {
+    return XdParentToManyChildrenLink(entityTypeCompanion(), oppositeLink, dbPropertyName, required = false)
 }
 
 /**
  * Parent end [1..N] of aggregation association
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdChildren1_N(oppositeLink: KProperty1<T, R?>): XdParentToManyChildrenLink<R, T> {
-    return XdParentToManyChildrenLink(entityTypeCompanion(), oppositeLink, required = true)
+inline fun <R : XdEntity, reified T : XdEntity> xdChildren1_N(oppositeLink: KProperty1<T, R?>, dbPropertyName: String? = null): XdParentToManyChildrenLink<R, T> {
+    return XdParentToManyChildrenLink(entityTypeCompanion(), oppositeLink, dbPropertyName, required = true)
 }
 
 /**
  * Child end of scalar aggregation association
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdParent(oppositeLink: KProperty1<T, R?>): XdOneChildToParentLink<R, T> {
-    return XdOneChildToParentLink(entityTypeCompanion(), oppositeLink)
+inline fun <R : XdEntity, reified T : XdEntity> xdParent(oppositeLink: KProperty1<T, R?>, dbPropertyName: String? = null): XdOneChildToParentLink<R, T> {
+    return XdOneChildToParentLink(entityTypeCompanion(), oppositeLink, dbPropertyName)
 }
 
 /**
  * Child end of scalar aggregation association.
  * Should be used if entity has several parent links
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdMultiParent(oppositeLink: KProperty1<T, R?>): XdOneChildToMultiParentLink<R, T> {
-    return XdOneChildToMultiParentLink(entityTypeCompanion(), oppositeLink)
+inline fun <R : XdEntity, reified T : XdEntity> xdMultiParent(oppositeLink: KProperty1<T, R?>, dbPropertyName: String? = null): XdOneChildToMultiParentLink<R, T> {
+    return XdOneChildToMultiParentLink(entityTypeCompanion(), oppositeLink, dbPropertyName)
 }
 
 /**
  * Child end of vector aggregation association
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdParent(oppositeLink: KProperty1<T, XdMutableQuery<R>>): XdManyChildrenToParentLink<R, T> {
-    return XdManyChildrenToParentLink(entityTypeCompanion(), oppositeLink)
+inline fun <R : XdEntity, reified T : XdEntity> xdParent(oppositeLink: KProperty1<T, XdMutableQuery<R>>, dbPropertyName: String? = null): XdManyChildrenToParentLink<R, T> {
+    return XdManyChildrenToParentLink(entityTypeCompanion(), oppositeLink, dbPropertyName)
 }
 
 /**
  * Child end of vector aggregation association
  * Should be used if entity has several parent links
  */
-inline fun <R : XdEntity, reified T : XdEntity> xdMultiParent(oppositeLink: KProperty1<T, XdMutableQuery<R>>): XdManyChildrenToMultiParentLink<R, T> {
-    return XdManyChildrenToMultiParentLink(entityTypeCompanion(), oppositeLink)
+inline fun <R : XdEntity, reified T : XdEntity> xdMultiParent(oppositeLink: KProperty1<T, XdMutableQuery<R>>, dbPropertyName: String? = null): XdManyChildrenToMultiParentLink<R, T> {
+    return XdManyChildrenToMultiParentLink(entityTypeCompanion(), oppositeLink, dbPropertyName)
 }
 
 inline fun <reified T : XdEntity> entityTypeCompanion(): XdEntityType<T> {

--- a/src/main/kotlin/kotlinx.dnq/link/XdManyChildrenToMultiParentLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdManyChildrenToMultiParentLink.kt
@@ -13,10 +13,16 @@ import kotlin.reflect.KProperty1
 
 class XdManyChildrenToMultiParentLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
-        override val oppositeField: KProperty1<T, XdMutableQuery<R>>) :
-        ReadWriteProperty<R, T?>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._0_1, AssociationEndType.ChildEnd, onDelete = OnDeletePolicy.CLEAR, onTargetDelete = OnDeletePolicy.CASCADE) {
+        override val oppositeField: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String?
+) : ReadWriteProperty<R, T?>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._0_1,
+        AssociationEndType.ChildEnd,
+        onDelete = OnDeletePolicy.CLEAR,
+        onTargetDelete = OnDeletePolicy.CASCADE
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T? {
         return AssociationSemantics.getToOne(thisRef.entity, property.name)?.let { value ->

--- a/src/main/kotlin/kotlinx.dnq/link/XdManyChildrenToParentLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdManyChildrenToParentLink.kt
@@ -14,10 +14,16 @@ import kotlin.reflect.KProperty1
 
 class XdManyChildrenToParentLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
-        override val oppositeField: KProperty1<T, XdMutableQuery<R>>) :
-        ReadWriteProperty<R, T>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._1, AssociationEndType.ChildEnd, onDelete = OnDeletePolicy.CLEAR, onTargetDelete = OnDeletePolicy.CASCADE) {
+        override val oppositeField: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String?
+) : ReadWriteProperty<R, T>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._1,
+        AssociationEndType.ChildEnd,
+        onDelete = OnDeletePolicy.CLEAR,
+        onTargetDelete = OnDeletePolicy.CASCADE
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T {
         val parent = AssociationSemantics.getToOne(thisRef.entity, property.name) ?:

--- a/src/main/kotlin/kotlinx.dnq/link/XdManyToManyLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdManyToManyLink.kt
@@ -16,12 +16,18 @@ import kotlin.reflect.KProperty1
 open class XdManyToManyLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         override val oppositeField: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
         onTargetDeletePolicy: OnDeletePolicy,
-        required: Boolean) :
-        ReadOnlyProperty<R, XdMutableQuery<T>>,
-        XdLink<R, T>(entityType, null,
-                if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n, AssociationEndType.UndirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        required: Boolean
+) : ReadOnlyProperty<R, XdMutableQuery<T>>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n,
+        AssociationEndType.UndirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): XdMutableQuery<T> {
         return object : XdMutableQuery<T>(entityType) {

--- a/src/main/kotlin/kotlinx.dnq/link/XdManyToOneOptionalLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdManyToOneOptionalLink.kt
@@ -14,11 +14,17 @@ import kotlin.reflect.KProperty1
 class XdManyToOneOptionalLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         override val oppositeField: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
-        onTargetDeletePolicy: OnDeletePolicy) :
-        ReadWriteProperty<R, T?>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._0_1, AssociationEndType.UndirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        onTargetDeletePolicy: OnDeletePolicy
+) : ReadWriteProperty<R, T?>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._0_1,
+        AssociationEndType.UndirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T? {
         return AssociationSemantics.getToOne(thisRef.entity, property.name)?.let { value ->

--- a/src/main/kotlin/kotlinx.dnq/link/XdManyToOneRequiredLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdManyToOneRequiredLink.kt
@@ -15,11 +15,17 @@ import kotlin.reflect.KProperty1
 class XdManyToOneRequiredLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         override val oppositeField: KProperty1<T, XdMutableQuery<R>>,
+        dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
-        onTargetDeletePolicy: OnDeletePolicy) :
-        ReadWriteProperty<R, T>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._1, AssociationEndType.UndirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        onTargetDeletePolicy: OnDeletePolicy
+) : ReadWriteProperty<R, T>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._1,
+        AssociationEndType.UndirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T {
         val entity = AssociationSemantics.getToOne(thisRef.entity, property.name) ?:

--- a/src/main/kotlin/kotlinx.dnq/link/XdOneChildToMultiParentLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdOneChildToMultiParentLink.kt
@@ -12,10 +12,16 @@ import kotlin.reflect.KProperty1
 
 class XdOneChildToMultiParentLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
-        override val oppositeField: KProperty1<T, R?>) :
-        ReadWriteProperty<R, T?>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._1, AssociationEndType.ChildEnd, onDelete = OnDeletePolicy.CLEAR, onTargetDelete = OnDeletePolicy.CASCADE) {
+        override val oppositeField: KProperty1<T, R?>,
+        dbPropertyName: String?
+) : ReadWriteProperty<R, T?>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._1,
+        AssociationEndType.ChildEnd,
+        onDelete = OnDeletePolicy.CLEAR,
+        onTargetDelete = OnDeletePolicy.CASCADE
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T? {
         return AssociationSemantics.getToOne(thisRef.entity, property.name)?.let { value ->

--- a/src/main/kotlin/kotlinx.dnq/link/XdOneChildToParentLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdOneChildToParentLink.kt
@@ -13,10 +13,16 @@ import kotlin.reflect.KProperty1
 
 class XdOneChildToParentLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
-        override val oppositeField: KProperty1<T, R?>) :
-        ReadWriteProperty<R, T>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._1, AssociationEndType.ChildEnd, onDelete = OnDeletePolicy.CLEAR, onTargetDelete = OnDeletePolicy.CASCADE) {
+        override val oppositeField: KProperty1<T, R?>,
+        dbPropertyName: String?
+) : ReadWriteProperty<R, T>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._1,
+        AssociationEndType.ChildEnd,
+        onDelete = OnDeletePolicy.CLEAR,
+        onTargetDelete = OnDeletePolicy.CASCADE
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T {
         val parent = AssociationSemantics.getToOne(thisRef.entity, property.name) ?:

--- a/src/main/kotlin/kotlinx.dnq/link/XdOneToManyLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdOneToManyLink.kt
@@ -16,12 +16,18 @@ import kotlin.reflect.KProperty1
 open class XdOneToManyLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         override val oppositeField: KProperty1<T, R?>,
+        dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
         onTargetDeletePolicy: OnDeletePolicy,
-        required: Boolean) :
-        ReadOnlyProperty<R, XdMutableQuery<T>>,
-        XdLink<R, T>(entityType, null,
-                if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n, AssociationEndType.UndirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        required: Boolean
+) : ReadOnlyProperty<R, XdMutableQuery<T>>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n,
+        AssociationEndType.UndirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): XdMutableQuery<T> {
         return object : XdMutableQuery<T>(entityType) {

--- a/src/main/kotlin/kotlinx.dnq/link/XdOneToOneOptionalLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdOneToOneOptionalLink.kt
@@ -13,11 +13,17 @@ import kotlin.reflect.KProperty1
 class XdOneToOneOptionalLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         override val oppositeField: KProperty1<T, R?>,
+        dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
-        onTargetDeletePolicy: OnDeletePolicy) :
-        ReadWriteProperty<R, T?>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._0_1, AssociationEndType.UndirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        onTargetDeletePolicy: OnDeletePolicy
+) : ReadWriteProperty<R, T?>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._0_1,
+        AssociationEndType.UndirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T? {
         return AssociationSemantics.getToOne(thisRef.entity, property.name)?.let { value ->

--- a/src/main/kotlin/kotlinx.dnq/link/XdOneToOneRequiredLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdOneToOneRequiredLink.kt
@@ -14,11 +14,17 @@ import kotlin.reflect.KProperty1
 class XdOneToOneRequiredLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         override val oppositeField: KProperty1<T, R?>,
+        dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
-        onTargetDeletePolicy: OnDeletePolicy) :
-        ReadWriteProperty<R, T>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._1, AssociationEndType.UndirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        onTargetDeletePolicy: OnDeletePolicy
+) : ReadWriteProperty<R, T>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._1,
+        AssociationEndType.UndirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T {
         val entity = AssociationSemantics.getToOne(thisRef.entity, property.name) ?:

--- a/src/main/kotlin/kotlinx.dnq/link/XdParentToManyChildrenLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdParentToManyChildrenLink.kt
@@ -16,10 +16,16 @@ import kotlin.reflect.KProperty1
 open class XdParentToManyChildrenLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         override val oppositeField: KProperty1<T, R?>,
-        required: Boolean) :
-        ReadOnlyProperty<R, XdMutableQuery<T>>,
-        XdLink<R, T>(entityType, null,
-                if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n, AssociationEndType.ParentEnd, onDelete = OnDeletePolicy.CASCADE, onTargetDelete = OnDeletePolicy.CLEAR) {
+        dbPropertyName: String?,
+        required: Boolean
+) : ReadOnlyProperty<R, XdMutableQuery<T>>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n,
+        AssociationEndType.ParentEnd,
+        onDelete = OnDeletePolicy.CASCADE,
+        onTargetDelete = OnDeletePolicy.CLEAR
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): XdMutableQuery<T> {
         return object : XdMutableQuery<T>(entityType) {

--- a/src/main/kotlin/kotlinx.dnq/link/XdParentToOneOptionalChildLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdParentToOneOptionalChildLink.kt
@@ -12,10 +12,16 @@ import kotlin.reflect.KProperty1
 
 class XdParentToOneOptionalChildLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
-        override val oppositeField: KProperty1<T, R?>) :
-        ReadWriteProperty<R, T?>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._0_1, AssociationEndType.ParentEnd, onDelete = OnDeletePolicy.CASCADE, onTargetDelete = OnDeletePolicy.CLEAR) {
+        override val oppositeField: KProperty1<T, R?>,
+        dbPropertyName: String?
+) : ReadWriteProperty<R, T?>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._0_1,
+        AssociationEndType.ParentEnd,
+        onDelete = OnDeletePolicy.CASCADE,
+        onTargetDelete = OnDeletePolicy.CLEAR
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T? {
         return AssociationSemantics.getToOne(thisRef.entity, property.name)?.let { value ->

--- a/src/main/kotlin/kotlinx.dnq/link/XdParentToOneRequiredChildLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdParentToOneRequiredChildLink.kt
@@ -13,10 +13,16 @@ import kotlin.reflect.KProperty1
 
 class XdParentToOneRequiredChildLink<R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
-        override val oppositeField: KProperty1<T, R?>) :
-        ReadWriteProperty<R, T>,
-        XdLink<R, T>(entityType, null,
-                AssociationEndCardinality._1, AssociationEndType.ParentEnd, onDelete = OnDeletePolicy.CASCADE, onTargetDelete = OnDeletePolicy.CLEAR) {
+        override val oppositeField: KProperty1<T, R?>,
+        dbPropertyName: String?
+) : ReadWriteProperty<R, T>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._1,
+        AssociationEndType.ParentEnd,
+        onDelete = OnDeletePolicy.CASCADE,
+        onTargetDelete = OnDeletePolicy.CLEAR
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T {
         val entity = AssociationSemantics.getToOne(thisRef.entity, property.name) ?:

--- a/src/main/kotlin/kotlinx.dnq/link/XdToManyLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdToManyLink.kt
@@ -17,10 +17,15 @@ open class XdToManyLink<in R : XdEntity, T : XdEntity>(
         dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
         onTargetDeletePolicy: OnDeletePolicy,
-        required: Boolean) :
-        ReadOnlyProperty<R, XdMutableQuery<T>>,
-        XdLink<R, T>(entityType, dbPropertyName,
-                if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n, AssociationEndType.DirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        required: Boolean
+) : ReadOnlyProperty<R, XdMutableQuery<T>>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        if (required) AssociationEndCardinality._1_n else AssociationEndCardinality._0_n,
+        AssociationEndType.DirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): XdMutableQuery<T> {
         return object : XdMutableQuery<T>(entityType) {

--- a/src/main/kotlin/kotlinx.dnq/link/XdToOneOptionalLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdToOneOptionalLink.kt
@@ -13,10 +13,15 @@ class XdToOneOptionalLink<in R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
-        onTargetDeletePolicy: OnDeletePolicy) :
-        ReadWriteProperty<R, T?>,
-        XdLink<R, T>(entityType, dbPropertyName,
-                AssociationEndCardinality._0_1, AssociationEndType.DirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        onTargetDeletePolicy: OnDeletePolicy
+) : ReadWriteProperty<R, T?>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._0_1,
+        AssociationEndType.DirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T? {
         return AssociationSemantics.getToOne(thisRef.entity, dbPropertyName ?: property.name)?.let { value ->

--- a/src/main/kotlin/kotlinx.dnq/link/XdToOneRequiredLink.kt
+++ b/src/main/kotlin/kotlinx.dnq/link/XdToOneRequiredLink.kt
@@ -14,10 +14,15 @@ class XdToOneRequiredLink<in R : XdEntity, T : XdEntity>(
         val entityType: XdEntityType<T>,
         dbPropertyName: String?,
         onDeletePolicy: OnDeletePolicy,
-        onTargetDeletePolicy: OnDeletePolicy) :
-        ReadWriteProperty<R, T>,
-        XdLink<R, T>(entityType, dbPropertyName,
-                AssociationEndCardinality._1, AssociationEndType.DirectedAssociationEnd, onDeletePolicy, onTargetDeletePolicy) {
+        onTargetDeletePolicy: OnDeletePolicy
+) : ReadWriteProperty<R, T>, XdLink<R, T>(
+        entityType,
+        dbPropertyName,
+        AssociationEndCardinality._1,
+        AssociationEndType.DirectedAssociationEnd,
+        onDeletePolicy,
+        onTargetDeletePolicy
+) {
 
     override fun getValue(thisRef: R, property: KProperty<*>): T {
         val entity = AssociationSemantics.getToOne(thisRef.entity, dbPropertyName ?: property.name) ?:

--- a/src/main/kotlin/kotlinx.dnq/util/ReflectionUtil.kt
+++ b/src/main/kotlin/kotlinx.dnq/util/ReflectionUtil.kt
@@ -132,8 +132,10 @@ fun <R : XdEntity> KProperty1<R, *>.getDBName(klass: KClass<R>): String {
 }
 
 fun <R : XdEntity> KProperty1<R, *>.getDBName(entityType: XdEntityType<R>): String {
-    val delegate = XdModel[entityType]?.simpleProperties?.get(this)?.delegate
-    return delegate?.dbPropertyName ?: this.name
+    val node = XdModel[entityType]
+    return node?.simpleProperties?.get(this)?.delegate?.dbPropertyName
+            ?: node?.linkProperties?.get(this)?.delegate?.dbPropertyName
+            ?: this.name
 }
 
 val Class<*>.memberFields: Sequence<Field>

--- a/src/test/kotlin/kotlinx.dnq/DBTest.kt
+++ b/src/test/kotlin/kotlinx.dnq/DBTest.kt
@@ -35,6 +35,7 @@ abstract class DBTest {
         var isGuest by xdBooleanProp()
         var registered by xdDateTimeProp()
         val contacts by xdLink0_N(Contact::user)
+        var supervisor by xdLink0_1(User, "boss")
 
         val groups by xdLink0_N(Group::users, onDelete = CLEAR, onTargetDelete = CLEAR)
     }

--- a/src/test/kotlin/kotlinx.dnq/query/QueryTest.kt
+++ b/src/test/kotlin/kotlinx.dnq/query/QueryTest.kt
@@ -4,6 +4,7 @@ import kotlinx.dnq.DBTest
 import kotlinx.dnq.transactional
 import org.junit.Test
 import java.util.*
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -45,6 +46,24 @@ class QueryTest : DBTest() {
                 skill = 1
             }
             assertNotNull(User.all().firstOrNull())
+        }
+    }
+
+    @Test
+    fun `query should obey custom db names of link properties`() {
+        store.transactional {
+            User.new {
+                login = "user1"
+                skill = 5
+                supervisor = User.new {
+                    login = "boss"
+                    skill = 555
+                }
+            }
+        }
+
+        store.transactional {
+            assertEquals(1, User.query(User::supervisor ne null).size())
         }
     }
 }


### PR DESCRIPTION
Also the change fixes querying like this `User.query(User::supervisor eq null)`, where `supervisor` is a link property with custom dbPropertyName.
Unfortunately it may break an existing code if someone didn't bother to use named parameters. Like this `val myProp by xdLink1_N(MyType, CASCADE)`.