### PR TITLE
Don't share persistent proxy classes between different entity types #JPS-5300

### DIFF
--- a/src/main/kotlin/kotlinx.dnq/util/XdHierarchyNode.kt
+++ b/src/main/kotlin/kotlinx.dnq/util/XdHierarchyNode.kt
@@ -72,6 +72,7 @@ class XdHierarchyNode(val entityType: XdEntityType<*>, val parentNode: XdHierarc
         ProxyFactory().apply {
             superclass = persistentClass
             setFilter { isNotFinalize(it) }
+            isUseCache = false
         }.create(emptyArray(), emptyArray()).apply {
             this as ProxyObject
             handler = PersistentClassMethodHandler(this, xdEntityType)


### PR DESCRIPTION
Originally it was fixed in https://github.com/JetBrains/xodus-dnq/commit/854b4ccb4f2fe67f51a89b4e37331bfb95b973e8, but then regressed in https://github.com/JetBrains/xodus-dnq/commit/003cdb3da27fcab0d780bfae40c30041443f460c.