### PR TITLE
fix for primitive types in filtering api

### DIFF
--- a/src/main/kotlin/kotlinx.dnq/query/XdFilteringQuery.kt
+++ b/src/main/kotlin/kotlinx.dnq/query/XdFilteringQuery.kt
@@ -89,17 +89,34 @@ class SearchingEntity(private val _type: String, private val _entityStore: Trans
             val simpleProperty = it ?: return 0
             return when (simpleProperty.property.returnType.javaType) {
                 java.lang.String::class.java -> ""
+
+                java.lang.Boolean.TYPE -> false
                 java.lang.Boolean::class.java -> false
+
+                java.lang.Byte.TYPE -> 0.toByte()
                 java.lang.Byte::class.java -> 0.toByte()
+
+                java.lang.Short.TYPE -> 0.toShort()
                 java.lang.Short::class.java -> 0.toShort()
+
+                java.lang.Character.TYPE -> 0.toChar()
                 java.lang.Character::class.java -> 0.toChar()
+
+                java.lang.Integer.TYPE -> 0
                 java.lang.Integer::class.java -> 0
+
+                java.lang.Long.TYPE -> 0.toLong()
                 java.lang.Long::class.java -> 0.toLong()
+
                 DateTime::class.java -> 0.toLong()
+
+                java.lang.Float.TYPE -> 0.toFloat()
                 java.lang.Float::class.java -> 0.toFloat()
+
+                java.lang.Double.TYPE -> 0.toDouble()
                 java.lang.Double::class.java -> 0.toDouble()
                 else -> {
-                    0
+                    ""
                 }
             }
         }

--- a/src/test/kotlin/kotlinx.dnq/query/FilterQueryPropertiesTest.kt
+++ b/src/test/kotlin/kotlinx.dnq/query/FilterQueryPropertiesTest.kt
@@ -221,12 +221,13 @@ class FilterQueryPropertiesTest : DBTest() {
             User.new {
                 login = "login"
                 isMale = true
+                isGuest = true
                 skill = 1
             }
         }
         store.transactional {
             User.filter {
-                it.isMale eq true
+                (it.isMale eq true) or (it.isGuest eq true)
             }.apply {
                 assertEquals(1, size())
             }


### PR DESCRIPTION
fix for primitive types in filtering api for properties like `var isGuest by xdBooleanProp()`