### PR TITLE
Tune info level logging

### DIFF
--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
@@ -141,7 +141,7 @@ open class TransientEntityStoreImpl : TransientEntityStore {
 
         eventsMultiplexer?.onClose(this)
 
-        logger.info { "Close transient store." }
+        logger.debug { "Close transient store." }
         closed = true
 
         val sessionsSize = sessions.size

--- a/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/EventsMultiplexer.kt
+++ b/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/EventsMultiplexer.kt
@@ -128,7 +128,7 @@ open class EventsMultiplexer @JvmOverloads constructor(val asyncJobProcessor: Jo
     }
 
     fun close() {
-        logger.info { "Cleaning EventsMultiplexer listeners" }
+        logger.debug { "Cleaning EventsMultiplexer listeners" }
 
         val notClosedListeners = rwl.write {
             isOpen = false


### PR DESCRIPTION
Only log production relevant information on level INFO and so avoid cluttering log output.

I want to use xodus-dnq in an environment where I can not control the log configuration and therefore can not fine tune / change the log level of a 3rd party library.