### PR TITLE
Fix #75

### DIFF
--- a/dnq/src/main/kotlin/kotlinx/dnq/util/XdHierarchyNode.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/XdHierarchyNode.kt
@@ -93,7 +93,7 @@ class XdHierarchyNode(val entityType: XdEntityType<*>, val parentNode: XdHierarc
     }
 
     override fun toString(): String {
-        return "${this.javaClass.simpleName}(${entityType.entityType})"
+        return "${this::class.java.simpleName}(${entityType.entityType})"
     }
 
     private var arePropertiesInited = false


### PR DESCRIPTION
Although as per tests in my application, Xodus itself (not Xodus-DNQ) throws some InaccessibleObjectException, but it seems unrelated to Xodus-DNQ and it does not crash whole application, so it looks good to me :)

> java.lang.reflect.InaccessibleObjectException: Unable to make public void sun.nio.ch.FileChannelImpl.setUninterruptible() accessible: module java.base does not "exports sun.nio.ch" to unnamed module @3febb011
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357) ~[?:?]
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297) ~[?:?]
	at java.lang.reflect.Method.checkCanSetAccessible(Method.java:199) ~[?:?]
	at java.lang.reflect.Method.setAccessible(Method.java:193) ~[?:?]
	at jetbrains.exodus.io.FileDataWriter$Companion$setUninterruptibleMethod$1.invoke(FileDataWriter.kt:188) ~[xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.io.FileDataWriter$Companion$setUninterruptibleMethod$1.invoke(FileDataWriter.kt:185) ~[xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.util.UnsafeHolder.doPrivileged$lambda-0(UnsafeHolder.kt:30) ~[xodus-utils-1.3.505.jar:1.3.505]
	at java.security.AccessController.doPrivileged(AccessController.java:554) [?:?]
	at jetbrains.exodus.util.UnsafeHolder.doPrivileged(UnsafeHolder.kt:29) [xodus-utils-1.3.505.jar:1.3.505]
	at jetbrains.exodus.io.FileDataWriter.<clinit>(FileDataWriter.kt:185) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.io.FileDataReaderWriterProvider.newFileDataWriter(FileDataReaderWriterProvider.kt:48) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.io.FileDataReaderWriterProvider.newReaderWriter(FileDataReaderWriterProvider.kt:30) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.log.LogConfig.createReaderWriter(LogConfig.java:359) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.log.LogConfig.getReader(LogConfig.java:125) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.log.Log.<init>(Log.kt:52) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.env.Environments.newLogInstance(Environments.kt:117) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.env.Environments.newLogInstance(Environments.kt:81) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.env.Environments.newLogInstance(Environments.kt:77) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.env.Environments$newInstance$4.invoke(Environments.kt:46) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.env.Environments$newInstance$4.invoke(Environments.kt:46) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.env.Environments.prepare(Environments.kt:120) [xodus-environment-1.3.505.jar:1.3.505]
	at jetbrains.exodus.env.Environments.newInstance(Environments.kt:46) [xodus-environment-1.3.505.jar:1.3.505]
	at kotlinx.dnq.store.container.EntityStoreHelperKt.createTransientEntityStore(EntityStoreHelper.kt:40) [dnq-0.0.3.jar:?]
	at kotlinx.dnq.store.container.StaticStoreContainer.init(StaticStoreContainer.kt:35) [dnq-0.0.3.jar:?]
	at kotlinx.dnq.store.container.StaticStoreContainer.init$default(StaticStoreContainer.kt:34) [dnq-0.0.3.jar:?]
	at by.enrollie.eversity.database.InitDatabaseKt.initXodusDatabase(initDatabase.kt:40) [main/:?]
	at by.enrollie.eversity.ApplicationKt.module(Application.kt:133) [main/:?]
	at by.enrollie.eversity.ApplicationKt.module$default(Application.kt:88) [main/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod(CallerImpl.kt:97) [kotlin-reflect-1.6.10.jar:1.6.10-release-923(1.6.10)]
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Static.call(CallerImpl.kt:106) [kotlin-reflect-1.6.10.jar:1.6.10-release-923(1.6.10)]
	at kotlin.reflect.jvm.internal.KCallableImpl.callDefaultMethod$kotlin_reflection(KCallableImpl.kt:173) [kotlin-reflect-1.6.10.jar:1.6.10-release-923(1.6.10)]
	at kotlin.reflect.jvm.internal.KCallableImpl.callBy(KCallableImpl.kt:112) [kotlin-reflect-1.6.10.jar:1.6.10-release-923(1.6.10)]
	at io.ktor.server.engine.internal.CallableUtilsKt.callFunctionWithInjection(CallableUtils.kt:119) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.internal.CallableUtilsKt.executeModuleFunction(CallableUtils.kt:36) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading$launchModuleByName$1.invoke(ApplicationEngineEnvironmentReloading.kt:332) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading$launchModuleByName$1.invoke(ApplicationEngineEnvironmentReloading.kt:331) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading.avoidingDoubleStartupFor(ApplicationEngineEnvironmentReloading.kt:356) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading.launchModuleByName(ApplicationEngineEnvironmentReloading.kt:331) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading.access$launchModuleByName(ApplicationEngineEnvironmentReloading.kt:30) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading$instantiateAndConfigureApplication$1.invoke(ApplicationEngineEnvironmentReloading.kt:312) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading$instantiateAndConfigureApplication$1.invoke(ApplicationEngineEnvironmentReloading.kt:310) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading.avoidingDoubleStartup(ApplicationEngineEnvironmentReloading.kt:338) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading.instantiateAndConfigureApplication(ApplicationEngineEnvironmentReloading.kt:310) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading.createApplication(ApplicationEngineEnvironmentReloading.kt:143) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.engine.ApplicationEngineEnvironmentReloading.start(ApplicationEngineEnvironmentReloading.kt:277) [ktor-server-host-common-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.netty.NettyApplicationEngine.start(NettyApplicationEngine.kt:174) [ktor-server-netty-jvm-1.6.7.jar:1.6.7]
	at io.ktor.server.netty.EngineMain.main(EngineMain.kt:26) [ktor-server-netty-jvm-1.6.7.jar:1.6.7]
	at by.enrollie.eversity.ApplicationKt.main(Application.kt:84) [main/:?]
