### PR TITLE
Updated xodus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.exodus_version = '9.9.121'
+    ext.exodus_version = '9.9.122'
     ext.dokka_version = '1.7.20'
     ext.log4j_version = '2.17.1'
     ext.google_truth_version = '1.4.2'

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/container/StaticStoreContainer.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/container/StaticStoreContainer.kt
@@ -21,6 +21,7 @@ import com.orientechnologies.orient.core.db.ODatabaseType
 import com.orientechnologies.orient.core.db.OrientDB
 import com.orientechnologies.orient.core.db.OrientDBConfig
 import jetbrains.exodus.database.TransientEntityStore
+import jetbrains.exodus.entitystore.orientdb.ODatabaseProvider
 import jetbrains.exodus.entitystore.orientdb.ODatabaseProviderImpl
 import jetbrains.exodus.env.EnvironmentConfig
 import java.io.File
@@ -44,15 +45,17 @@ object StaticStoreContainer : StoreContainer {
         val db = OrientDB("memory", builder.build())
         val databaseType = ODatabaseType.MEMORY
         db.createIfNotExists(entityStoreName, databaseType,"admin", "password", "admin")
-        val dbProvider = ODatabaseProviderImpl(
+        dbProvider = ODatabaseProviderImpl(
             db,
             entityStoreName,
             "admin",
             "password",
             databaseType,
         )
-        val store = createTransientEntityStore(dbProvider, entityStoreName)
+        val store = createTransientEntityStore(dbProvider!!, entityStoreName)
         this.store = store
         return store
     }
+
+    var dbProvider: ODatabaseProvider? = null
 }

--- a/dnq/src/test/kotlin/kotlinx/dnq/DBTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DBTest.kt
@@ -28,6 +28,7 @@ import jetbrains.exodus.entitystore.TransientChangesMultiplexer
 import jetbrains.exodus.entitystore.Where
 import jetbrains.exodus.entitystore.Where.SYNC_AFTER_FLUSH
 import jetbrains.exodus.entitystore.Where.SYNC_BEFORE_FLUSH_BEFORE_CONSTRAINTS
+import jetbrains.exodus.entitystore.orientdb.OPersistentEntityStore
 import jetbrains.exodus.util.IOUtil
 import kotlinx.dnq.link.OnDeletePolicy.CLEAR
 import kotlinx.dnq.listener.XdEntityListener
@@ -185,6 +186,7 @@ abstract class DBTest {
                 eventsMultiplexer.removeListener(it.first.entity, it.second.asEntityListener())
             }
         }
+        StaticStoreContainer.dbProvider?.close()
         store.close()
     }
 


### PR DESCRIPTION
persistent store does not close DB privider, so it can be reused.