### PR TITLE
Xodus upgrade + not throwing the exception from session.abort

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '2.1.0'
-    ext.exodus_version = '9.9.168'
+    ext.exodus_version = '9.9.169'
     ext.dokka_version = '2.0.0'
     ext.log4j_version = '2.17.1'
     ext.google_truth_version = '1.4.2'

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
@@ -19,8 +19,9 @@ import jetbrains.exodus.database.TransientEntityStore
 import jetbrains.exodus.database.TransientStoreSession
 import jetbrains.exodus.entitystore.QueryCancellingPolicy
 import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
+import mu.KLogging
 
-internal object TransientEntityStoreExt {
+internal object TransientEntityStoreExt : KLogging() {
     fun <T> transactional(
         store: TransientEntityStore,
         queryCancellingPolicy: QueryCancellingPolicy? = null,
@@ -99,7 +100,12 @@ internal object TransientEntityStoreExt {
             throw e
         } finally {
             if (wasEx && session.isOpened) {
-                session.abort()
+                try {
+                    session.abort()
+                } catch (err: Exception) {
+                    // we don't want to miss the original error
+                    logger.error("Error while aborting uncommited session: ${err.message}", err)
+                }
             }
         }
     }


### PR DESCRIPTION
Calling session.abort can produce an exception, and the original exception that caused the abortion can be lost.