### PR TITLE
Adopt orientdb delete cascade test

### DIFF
--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
@@ -392,7 +392,7 @@ class TransientSessionImpl(
         changesTracker.changesDescription.filter {
             it.changeType == EntityChangeType.REMOVE
         }.map {
-            it.transientEntity
+            RemovedTransientEntity(it.transientEntity)
         }.forEach { txnEntity ->
             val processed = HashSet<Entity>()
             val modelMetaData = store.modelMetaData!!

--- a/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
@@ -22,6 +22,9 @@ import kotlinx.dnq.link.OnDeletePolicy.CLEAR
 import kotlinx.dnq.query.first
 import kotlinx.dnq.query.toList
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.thread
 
 class DeleteTest : DBTest() {
 
@@ -121,31 +124,57 @@ class DeleteTest : DBTest() {
     }
 
     @Test
-    fun clearCascade2() {
-        val (domain, server) = store.transactional {
-            val domain = Domain.new { name = "domain1" }
-            val server = Server.new { name = "server1" }
-            Instance.new {
-                name = "instance1"
-                this.parent = domain
-                this.server = server
-            }
-            Instance.new {
-                name = "instance2"
-                this.parent = domain
-                this.server = server
-            }
+    fun clearCascadeConcurrent() {
+        val server = store.transactional { Server.new { name = "server" } }
 
-            Pair(domain, server)
+        val domains = (0..1).map { i ->
+            store.transactional {
+                val domain = Domain.new { name = "domain$i" }
+
+                Instance.new { name = "instance$i"
+                    this.parent = domain
+                    this.server = server
+                }
+
+                domain
+            }
         }
 
-        store.transactional {
-            assertThat(server.instances.toList()).hasSize(2)
-            domain.delete()
+        val domain1 = domains.first()
+        val domain2 = domains.last()
+
+        val latch1 = CountDownLatch(1)
+        val latch2 = CountDownLatch(1)
+
+        val deleted = AtomicLong(0)
+
+        val t1 = thread {
+            store.transactional {
+                latch1.countDown()
+                domain1.delete()
+                latch2.await()
+            }
+            deleted.incrementAndGet()
         }
 
+        val t2 = thread {
+            store.transactional {
+                latch1.await()
+                domain2.delete()
+                latch2.countDown()
+            }
+            deleted.incrementAndGet()
+        }
+
+        t1.join(1000)
+        t2.join(1000)
+
+        assertThat(deleted.get()).isEqualTo(2L)
+
         store.transactional {
-            assertThat(server.instances.toList()).isEmpty()
+            assertThat(Domain.all().toList()).isEmpty()
+            assertThat(Server.all().toList()).hasSize(1)
+            assertThat(Instance.all().toList()).isEmpty()
         }
     }
 }

--- a/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
@@ -36,6 +36,9 @@ class DeleteTest : DBTest() {
     override fun registerEntityTypes() {
         super.registerEntityTypes()
         XdModel.registerNode(CompanyTeam)
+        XdModel.registerNode(Domain)
+        XdModel.registerNode(Server)
+        XdModel.registerNode(Instance)
     }
 
     @Test
@@ -92,6 +95,57 @@ class DeleteTest : DBTest() {
 
         store.transactional {
             assertThat(parent.nestedTeams.toList()).isEmpty()
+        }
+    }
+
+    class Domain(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<Domain>()
+
+        var name by xdRequiredStringProp(trimmed = true)
+        val instances by xdChildren0_N(Instance::parent)
+    }
+
+    class Server(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<Server>()
+
+        var name by xdRequiredStringProp(trimmed = true)
+        val instances by xdLink0_N(Instance::server, onTargetDelete = CLEAR)
+    }
+
+    class Instance(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<Instance>()
+
+        var name by xdRequiredStringProp(trimmed = true)
+        var parent: Domain by xdParent(Domain::instances)
+        var server: Server by xdLink1(Server::instances)
+    }
+
+    @Test
+    fun clearCascade2() {
+        val (domain, server) = store.transactional {
+            val domain = Domain.new { name = "domain1" }
+            val server = Server.new { name = "server1" }
+            Instance.new {
+                name = "instance1"
+                this.parent = domain
+                this.server = server
+            }
+            Instance.new {
+                name = "instance2"
+                this.parent = domain
+                this.server = server
+            }
+
+            Pair(domain, server)
+        }
+
+        store.transactional {
+            assertThat(server.instances.toList()).hasSize(2)
+            domain.delete()
+        }
+
+        store.transactional {
+            assertThat(server.instances.toList()).isEmpty()
         }
     }
 }

--- a/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
@@ -17,13 +17,15 @@ package kotlinx.dnq
 
 import com.google.common.truth.Truth.assertThat
 import jetbrains.exodus.entitystore.Entity
+import jetbrains.exodus.entitystore.EntityId
 import kotlinx.dnq.link.OnDeletePolicy.CASCADE
 import kotlinx.dnq.link.OnDeletePolicy.CLEAR
 import kotlinx.dnq.query.first
 import kotlinx.dnq.query.toList
 import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.thread
 
 class DeleteTest : DBTest() {
@@ -143,37 +145,41 @@ class DeleteTest : DBTest() {
         val domain1 = domains.first()
         val domain2 = domains.last()
 
-        val latch1 = CountDownLatch(1)
-        val latch2 = CountDownLatch(1)
+        println("server: ${server.entityId}, domain1: ${domain1.entityId}, domain2: ${domain2.entityId}")
 
-        val deleted = AtomicLong(0)
+        val bothTxStarted = CountDownLatch(2)
+        val firstTxCommited = CountDownLatch(1)
+
+        val deleted = Collections.newSetFromMap(ConcurrentHashMap<EntityId, Boolean>())
 
         val t1 = thread {
             store.transactional {
-                latch1.countDown()
+                bothTxStarted.countDown()
+                bothTxStarted.await()
                 domain1.delete()
-                latch2.await()
             }
-            deleted.incrementAndGet()
+            firstTxCommited.countDown()
+            deleted.add(domain1.entityId)
         }
 
         val t2 = thread {
             store.transactional {
-                latch1.await()
+                bothTxStarted.countDown()
+                bothTxStarted.await()
                 domain2.delete()
-                latch2.countDown()
+                firstTxCommited.await() // waiting for 1st to commit to cause 2nd tx replay
             }
-            deleted.incrementAndGet()
+            deleted.add(domain2.entityId)
         }
 
-        t1.join(1000)
-        t2.join(1000)
+        val toWait = Long.MAX_VALUE
+        t1.join(toWait)
+        t2.join(toWait)
 
-        assertThat(deleted.get()).isEqualTo(2L)
+        assertThat(deleted).isEqualTo(setOf(domain1.entityId, domain2.entityId))
 
         store.transactional {
             assertThat(Domain.all().toList()).isEmpty()
-            assertThat(Server.all().toList()).hasSize(1)
             assertThat(Instance.all().toList()).isEmpty()
         }
     }


### PR DESCRIPTION
Fixing "Entity was removed by you" error during concurrent cascade deletion