### PR TITLE
Deprecating unsafe methods in XdQuery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '2.1.0'
-    ext.exodus_version = '9.9.174'
+    ext.exodus_version = '9.9.176'
     ext.dokka_version = '2.0.0'
     ext.log4j_version = '2.17.1'
     ext.google_truth_version = '1.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '2.1.0'
-    ext.exodus_version = '9.9.170'
+    ext.exodus_version = '9.9.174'
     ext.dokka_version = '2.0.0'
     ext.log4j_version = '2.17.1'
     ext.google_truth_version = '1.4.2'

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/RemovedTransientEntity.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/RemovedTransientEntity.kt
@@ -328,7 +328,7 @@ internal class RemovedLinksEntityIterable(
             }
 
             override fun shouldBeDisposed(): Boolean {
-                throw IllegalStateException("Must not be called")
+                return false
             }
 
 

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
@@ -21,6 +21,7 @@ import jetbrains.exodus.database.TransientEntity
 import jetbrains.exodus.entitystore.Entity
 import jetbrains.exodus.entitystore.EntityId
 import jetbrains.exodus.entitystore.EntityIterable
+import jetbrains.exodus.entitystore.EntityIterator
 import jetbrains.exodus.entitystore.asOStoreTransaction
 import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityIterable
 import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
@@ -67,82 +68,85 @@ fun <T : XdEntity> Iterable<Entity>?.asQuery(entityType: XdEntityType<T>): XdQue
 }
 
 /**
- * Creates a [Sequence] instance that wraps the original query returning its results when being iterated.
+ * Performs an operation on `iterable`, disposing all used resources if it is an [EntityIterable].
  */
-fun <T : XdEntity> XdQuery<T>.asSequence(): Sequence<T> {
-    return entityIterable
-        .asSequence()
-        .map { entityType.wrap(it) }
+fun <T, R> useIterable(iterable: Iterable<T>, f: (Sequence<T>) -> R): R {
+    val iterator = iterable.iterator()
+
+    try {
+        return f(iterator.asSequence())
+    } finally {
+        if (iterator is EntityIterator && iterator.shouldBeDisposed()) {
+            iterator.dispose()
+        }
+    }
 }
 
 /**
- * Creates a [Sequence] instance that wraps the original query returning its results as entity ids when being iterated.
+ * Performs an operation on the results of this query, disposing all used resources after.
  */
-fun <T : XdEntity> XdQuery<T>.asIdSequence(): Sequence<EntityId> {
-    return entityIterable
-        .asSequence()
-        .map { it.id }
-}
-
+fun <T : XdEntity, R> XdQuery<T>.useEntitySequence(f: (Sequence<Entity>) -> R): R =
+    useIterable(entityIterable, f)
 
 /**
- * Creates an [Iterable] instance that wraps the original query returning its results when being iterated.
+ * Performs an operation on [XdEntity]s from the results of this query, disposing all used resources after.
  */
-fun <T : XdEntity> XdQuery<T>.asIterable(): Iterable<T> {
-    return asSequence().asIterable()
-}
+fun <T : XdEntity, R> XdQuery<T>.useSequence(f: (Sequence<T>) -> R): R =
+    useEntitySequence { s -> f(s.map { entityType.wrap(it) }) }
 
 /**
- * Creates an [Iterator] instance that iterates over query results.
+ * Performs an operation of [EntityId]s of the results of this query, disposing all used resources after.
  */
-operator fun <T : XdEntity> XdQuery<T>.iterator(): Iterator<T> = this.asSequence().iterator()
+fun <T : XdEntity, R> XdQuery<T>.useIdsSequence(f: (Sequence<EntityId>) -> R): R =
+    useEntitySequence { s -> f(s.map { it.id }) }
 
 /**
  * Appends all elements to the given [destination] collection.
  */
 fun <T : XdEntity, C : MutableCollection<in T>> XdQuery<T>.toCollection(destination: C) =
-    asSequence().toCollection(destination)
+    useSequence { it.toCollection(destination) }
 
 /**
  * Returns a [List] containing all results of the original query.
  */
-fun <T : XdEntity> XdQuery<T>.toList() = asSequence().toList()
+fun <T : XdEntity> XdQuery<T>.toList(): List<T> = useSequence { it.toList() }
 
 /**
  * Returns a [List] containing ids of all results of the original query.
  */
-fun <T : XdEntity> XdQuery<T>.toIdList() = asIdSequence().toList()
+fun <T : XdEntity> XdQuery<T>.toIdList(): List<EntityId> = useIdsSequence { it.toList() }
 
 /**
  * Returns a [MutableList] filled with all results of the original query.
  */
-fun <T : XdEntity> XdQuery<T>.toMutableList() = asSequence().toMutableList()
+fun <T : XdEntity> XdQuery<T>.toMutableList(): MutableList<T> = useSequence { it.toMutableList() }
 
 /**
  * Returns a [Set] of all results of the original query.
  *
  * The returned set preserves the element iteration order of the original query.
  */
-fun <T : XdEntity> XdQuery<T>.toSet() = asSequence().toSet()
+fun <T : XdEntity> XdQuery<T>.toSet(): Set<T> = useSequence { it.toSet() }
 
 /**
  * Returns a [HashSet] of all results of the original query.
  */
-fun <T : XdEntity> XdQuery<T>.toHashSet() = asSequence().toHashSet()
+fun <T : XdEntity> XdQuery<T>.toHashSet(): HashSet<T> = useSequence { it.toHashSet() }
 
 /**
  * Returns a [SortedSet] of all results of the original query.
  *
  * Elements in the set returned are sorted according to the given [comparator].
  */
-fun <T : XdEntity> XdQuery<T>.toSortedSet(comparator: Comparator<T>) = asSequence().toSortedSet(comparator)
+fun <T : XdEntity> XdQuery<T>.toSortedSet(comparator: Comparator<T>): SortedSet<T> =
+    useSequence { it.toSortedSet(comparator) }
 
 /**
  * Returns a mutable set containing all distinct results of the original query.
  *
  * The returned set preserves the element iteration order of the original query.
  */
-fun <T : XdEntity> XdQuery<T>.toMutableSet() = asSequence().toMutableSet()
+fun <T : XdEntity> XdQuery<T>.toMutableSet(): MutableSet<T> = useSequence { it.toMutableSet() }
 
 /**
  * Returns an empty query.
@@ -245,7 +249,7 @@ fun <T : XdEntity, S : XdEntity> XdQuery<S>.unionEach(
     entityType: XdEntityType<T>,
     queryFun: (S) -> XdQuery<T>
 ): XdQuery<T> {
-    return asIterable().unionEach(entityType, queryFun)
+    return useSequence { it.asIterable().unionEach(entityType, queryFun) }
 }
 
 /**
@@ -339,7 +343,7 @@ inline fun <reified T : XdEntity> XdEntityType<T>.query(it: Iterable<T?>): XdQue
     if (it is Collection && it.isEmpty()) {
         return emptyQuery()
     }
-    return return XdQueryImpl(it.mapNotNull { it?.entity }, this)
+    return XdQueryImpl(it.mapNotNull { it?.entity }, this)
 }
 
 /**
@@ -441,7 +445,7 @@ fun <T : XdEntity> XdQuery<T>?.size(): Int {
         YTDBEntityIterableBase.EMPTY -> 0
         is EntityIterable -> it.size().toInt()
         is Collection<*> -> it.size
-        else -> it.count()
+        else -> useEntitySequence { it.count() }
     }
 }
 
@@ -456,7 +460,7 @@ fun <T : XdEntity> XdQuery<T>?.roughSize(): Int {
         when (it) {
             is EntityIterable -> it.roughSize.toInt()
             is Collection<*> -> it.size
-            else -> it.count()
+            else -> useEntitySequence { it.count() }
         }
     }
 }
@@ -489,7 +493,7 @@ val <T : XdEntity> XdQuery<T>?.isEmpty: Boolean
                 if (queryEngine.isPersistentIterable(entIt)) {
                     (entIt as EntityIterable).isEmpty
                 } else {
-                    entIt.none()
+                    useIterable(entIt) { it.none() }
                 }
             }
         }
@@ -668,18 +672,15 @@ fun <T : XdEntity> XdQuery<T>.first(node: NodeBase): T {
  */
 fun <T : XdEntity> XdQuery<T>.firstOrNull(): T? {
     if (entityIterable is TransientEntityIterable){
-        return entityIterable.firstOrNull()?.let { entityType.wrap(it) }
+        return useIterable(entityIterable) { eit -> eit.firstOrNull()?.let { entityType.wrap(it) } }
     }
     val it = queryEngine.toEntityIterable(entityIterable)
-    return if (it is YTDBEntityIterableBase) {
-        it.unwrap().first?.let {
-            entityType.entityStore.session.newEntity(it)
-        }
+    val entity = if (it is YTDBEntityIterableBase) {
+        it.unwrap().first?.let { entityType.entityStore.session.newEntity(it) }
     } else {
-        it.firstOrNull()
-    }?.let {
-        entityType.wrap(it)
+        useIterable(it) { eit -> eit.firstOrNull() }
     }
+    return entity?.let { entityType.wrap(it) }
 }
 
 /**
@@ -716,15 +717,12 @@ fun <T : XdEntity> XdQuery<T>.last(node: NodeBase): T {
  */
 fun <T : XdEntity> XdQuery<T>.lastOrNull(): T? {
     val it = queryEngine.toEntityIterable(entityIterable)
-    return if (it is YTDBEntityIterableBase) {
-        it.unwrap().last?.let {
-            entityType.entityStore.session.newEntity(it)
-        }
+    val entity = if (it is YTDBEntityIterableBase) {
+        it.unwrap().last?.let { entityType.entityStore.session.newEntity(it) }
     } else {
-        it.lastOrNull()
-    }?.let {
-        entityType.wrap(it)
+        useIterable(it) { eit -> eit.lastOrNull() }
     }
+    return entity?.let { entityType.wrap(it) }
 }
 
 /**
@@ -741,7 +739,7 @@ fun <T : XdEntity> XdQuery<T>.lastOrNull(node: NodeBase): T? {
  * Returns the single query result, or throws an exception if the query is empty or has more than one result.
  */
 fun <T : XdEntity> XdQuery<T>.single(): T {
-    return asSequence().single()
+    return useSequence { it.single() }
 }
 
 /**
@@ -759,7 +757,7 @@ fun <T : XdEntity> XdQuery<T>.single(node: NodeBase): T {
  * Returns the single query result, or `null` if the query is empty or has more than one result.
  */
 fun <T : XdEntity> XdQuery<T>.singleOrNull(): T? {
-    return asSequence().singleOrNull()
+    return useSequence { it.singleOrNull() }
 }
 
 /**
@@ -802,7 +800,8 @@ fun <T : XdEntity> XdQuery<T>.reversed(): XdQuery<T> {
     return if (iterable is YTDBEntityIterableBase) {
         XdQueryImpl(wrap(iterable.unwrap().reverse()), entityType)
     } else {
-        XdQueryImpl(entityIterable.reversed(), entityType)
+
+        XdQueryImpl(useEntitySequence { it.asIterable().reversed() }, entityType)
     }
 }
 
@@ -813,7 +812,7 @@ fun <T : XdEntity> XdQuery<T>.reversed(): XdQuery<T> {
  * @see query
  */
 fun <T : XdEntity> XdQuery<T>.none(node: NodeBase): Boolean {
-    return query(node).asSequence().none()
+    return query(node).entityIterable.none()
 }
 
 /**
@@ -827,14 +826,14 @@ fun <T : XdEntity> XdMutableQuery<T>.addAll(elements: Sequence<T>) {
  * Adds all results of given [XdQuery] to this mutable query.
  */
 fun <T : XdEntity> XdMutableQuery<T>.addAll(elements: XdQuery<T>) {
-    addAll(elements.asSequence())
+    elements.useSequence { addAll(it) }
 }
 
 /**
  * Adds all results of given [Iterable] to this mutable query.
  */
 fun <T : XdEntity> XdMutableQuery<T>.addAll(elements: Iterable<T>) {
-    addAll(elements.asSequence())
+    useIterable(elements) { addAll(it) }
 }
 
 /**
@@ -848,7 +847,7 @@ fun <T : XdEntity> XdMutableQuery<T>.removeAll(elements: Sequence<T>) {
  * Removes all results of given [XdQuery] from this mutable query.
  */
 fun <T : XdEntity> XdMutableQuery<T>.removeAll(elements: XdQuery<T>) {
-    removeAll(elements.asSequence())
+    elements.useSequence { removeAll(it) }
 }
 
 /**
@@ -856,4 +855,8 @@ fun <T : XdEntity> XdMutableQuery<T>.removeAll(elements: XdQuery<T>) {
  */
 fun <T : XdEntity> XdMutableQuery<T>.removeAll(elements: Iterable<T>) {
     removeAll(elements.asSequence())
+}
+
+fun <T : XdEntity> XdQuery<T>.forEach(action: (T) -> Unit) {
+    useSequence { it.forEach(action) }
 }

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
@@ -101,6 +101,41 @@ fun <T : XdEntity, R> XdQuery<T>.useIdsSequence(f: (Sequence<EntityId>) -> R): R
     useEntitySequence { s -> f(s.map { it.id }) }
 
 /**
+ * Creates a [Sequence] instance that wraps the original query returning its results when being iterated.
+ */
+@Deprecated("Unsafe, because doesn't close the underlying EntityIterator, use useSequence instead", ReplaceWith("useSequence(f)"))
+fun <T : XdEntity> XdQuery<T>.asSequence(): Sequence<T> {
+    return entityIterable
+        .asSequence()
+        .map { entityType.wrap(it) }
+}
+
+/**
+ * Creates a [Sequence] instance that wraps the original query returning its results as entity ids when being iterated.
+ */
+@Deprecated("Unsafe, because doesn't close the underlying EntityIterator, use useIdSequence instead", ReplaceWith("useIdSequence(f)"))
+fun <T : XdEntity> XdQuery<T>.asIdSequence(): Sequence<EntityId> {
+    return entityIterable
+        .asSequence()
+        .map { it.id }
+}
+
+
+/**
+ * Creates an [Iterable] instance that wraps the original query returning its results when being iterated.
+ */
+@Deprecated("Unsafe, because doesn't close the underlying EntityIterator, use useSequence instead", ReplaceWith("useSequence(f)"))
+fun <T : XdEntity> XdQuery<T>.asIterable(): Iterable<T> {
+    return asSequence().asIterable()
+}
+
+/**
+ * Creates an [Iterator] instance that iterates over query results.
+ */
+@Deprecated("Unsafe, because the resulting iterator is not closed upon completion of the query.", ReplaceWith("useSequence(f)"))
+operator fun <T : XdEntity> XdQuery<T>.iterator(): Iterator<T> = this.asSequence().iterator()
+
+/**
  * Appends all elements to the given [destination] collection.
  */
 fun <T : XdEntity, C : MutableCollection<in T>> XdQuery<T>.toCollection(destination: C) =

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
@@ -102,8 +102,9 @@ fun <T : XdEntity, R> XdQuery<T>.useIdsSequence(f: (Sequence<EntityId>) -> R): R
 
 /**
  * Creates a [Sequence] instance that wraps the original query returning its results when being iterated.
+ *
+ * WARNING: This method is unsafe, because doesn't close the underlying [EntityIterator], use [useSequence] instead.
  */
-@Deprecated("Unsafe, because doesn't close the underlying EntityIterator, use useSequence instead", ReplaceWith("useSequence(f)"))
 fun <T : XdEntity> XdQuery<T>.asSequence(): Sequence<T> {
     return entityIterable
         .asSequence()
@@ -112,28 +113,26 @@ fun <T : XdEntity> XdQuery<T>.asSequence(): Sequence<T> {
 
 /**
  * Creates a [Sequence] instance that wraps the original query returning its results as entity ids when being iterated.
+ *
+ * WARNING: This method is unsafe because it doesn't close the underlying [EntityIterator], use [useIdsSequence] instead.
  */
-@Deprecated("Unsafe, because doesn't close the underlying EntityIterator, use useIdSequence instead", ReplaceWith("useIdSequence(f)"))
-fun <T : XdEntity> XdQuery<T>.asIdSequence(): Sequence<EntityId> {
-    return entityIterable
-        .asSequence()
-        .map { it.id }
-}
-
+fun <T : XdEntity> XdQuery<T>.asIdSequence(): Sequence<EntityId> =
+    entityIterable.asSequence().map { it.id }
 
 /**
  * Creates an [Iterable] instance that wraps the original query returning its results when being iterated.
+ *
+ * WARNING: This method is unsafe because it doesn't close the underlying [EntityIterator], use [useSequence] instead.
  */
-@Deprecated("Unsafe, because doesn't close the underlying EntityIterator, use useSequence instead", ReplaceWith("useSequence(f)"))
-fun <T : XdEntity> XdQuery<T>.asIterable(): Iterable<T> {
-    return asSequence().asIterable()
-}
+fun <T : XdEntity> XdQuery<T>.asIterable(): Iterable<T> = asSequence().asIterable()
 
 /**
  * Creates an [Iterator] instance that iterates over query results.
+ *
+ * WARNING: This method is unsafe because the resulting [EntityIterator] is not closed upon completion of the query,
+ * use [useSequence] instead.
  */
-@Deprecated("Unsafe, because the resulting iterator is not closed upon completion of the query.", ReplaceWith("useSequence(f)"))
-operator fun <T : XdEntity> XdQuery<T>.iterator(): Iterator<T> = this.asSequence().iterator()
+operator fun <T : XdEntity> XdQuery<T>.iterator(): Iterator<T> = asSequence().iterator()
 
 /**
  * Appends all elements to the given [destination] collection.

--- a/dnq/src/test/kotlin/kotlinx/dnq/AssociationSimpleTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/AssociationSimpleTest.kt
@@ -138,6 +138,7 @@ class AssociationSimpleTest : DBTest() {
         transactional {
             t1.tome2 = t2
             assertQuery(t2.tome1).containsExactly(t1)
+
             transactional(isNew = true) {
                 t2.delete()
             }

--- a/dnq/src/test/kotlin/kotlinx/dnq/DisposeCursorTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DisposeCursorTest.kt
@@ -17,8 +17,8 @@ package kotlinx.dnq
 
 import com.google.common.truth.Truth.assertThat
 import jetbrains.exodus.entitystore.Entity
-import kotlinx.dnq.query.asSequence
 import kotlinx.dnq.query.isEmpty
+import kotlinx.dnq.query.toList
 import org.junit.Before
 import org.junit.Test
 
@@ -66,9 +66,9 @@ class DisposeCursorTest : DBTest() {
     @Test
     fun testDisposeCursor() {
         transactional {
-            val user = XdUser.all()
-                    .asSequence()
-                    .firstOrNull { it.login == "vadim" && it.password == "vadim" }
+            val users = XdUser.all().toList()
+            val usersIsEmpty = XdUser.all().isEmpty
+            val user = users.firstOrNull { it.login == "vadim" && it.password == "vadim" }
 
             assertThat(user).isNotNull()
         }

--- a/dnq/src/test/kotlin/kotlinx/dnq/LinksTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/LinksTest.kt
@@ -44,7 +44,7 @@ class LinksTest : DBTest() {
                     .isNotEmpty()
             assertThat(root.nestedGroups.toList().map { it.name })
                     .containsExactly("A", "B", "C")
-            root.nestedGroups.asSequence().forEach {
+            root.nestedGroups.toList().forEach {
                 assertThat(it.parentGroup).isEqualTo(root)
                 assertThat(it.entity.getLink("parent")).isEqualTo(root.entity)
             }

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionsTest.kt
@@ -20,7 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import jetbrains.exodus.entitystore.Entity
 import kotlinx.dnq.*
 import kotlinx.dnq.query.first
-import kotlinx.dnq.query.iterator
+import kotlinx.dnq.query.toList
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -60,7 +60,7 @@ class ReadonlyTransactionsTest : DBTest() {
                 assertQuery(Something.all()).hasSize(count)
 
             }
-            val i = Something.all().iterator().asSequence().count()
+            val i = Something.all().toList().size
             assertThat(i).isEqualTo(count)
             assertQuery(Something.all()).hasSize(count)
         }
@@ -86,7 +86,7 @@ class ReadonlyTransactionsTest : DBTest() {
     fun `WD-2054 Read access to an instance of persistent class upgrades transaction to R-W`() {
         transactional { txn ->
             txn.setUpgradeHook(Runnable { fail("Transaction was upgraded") })
-            for (s in Something.all()) {
+            for (s in Something.all().toList()) {
                 assertThat(s.sometext).isNotNull()
             }
         }

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolationTest.kt
@@ -18,9 +18,9 @@ package kotlinx.dnq.concurrent.transaction
 
 import jetbrains.exodus.entitystore.Entity
 import kotlinx.dnq.*
-import kotlinx.dnq.query.asSequence
 import kotlinx.dnq.query.first
 import kotlinx.dnq.query.isNotEmpty
+import kotlinx.dnq.query.toList
 import org.junit.Test
 import kotlin.concurrent.thread
 
@@ -44,7 +44,7 @@ class TransactionsIsolationTest : DBTest() {
     val sizes: IntArray
         get() {
             val res = IntArray(3)
-            Something.all().asSequence().forEach { it ->
+            Something.all().toList().forEach { it ->
                 when {
                     it.sometext == "asomething" -> res[0] += 1
                     it.sometext == "bsomething" -> res[1] += 1
@@ -124,7 +124,7 @@ class TransactionsIsolationTest : DBTest() {
             var a = true
             while (!stopped) {
                 transactional { txn ->
-                    Something.all().asSequence().forEach {
+                    Something.all().toList().forEach {
                         it.sometext = if (a) "bsomething" else "asomething"
                     }
                     println("Update before flush.")

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
@@ -238,12 +238,12 @@ class DeleteCycleTest : DBTest() {
 
     private fun <XD : XdEntity> bulkDelete(txn: TransientStoreSession, seq: XdQuery<XD>) {
         var count = 0
-        var it = seq.iterator()
+        var it = seq.toList().iterator()
         while (it.hasNext()) {
             it.next().delete()
             if (++count % 100 == 0) {
                 txn.flush()
-                it = seq.iterator()
+                it = seq.toList().iterator()
             }
         }
         if (count % 100 != 0) {

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/DestructorTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/DestructorTest.kt
@@ -20,9 +20,10 @@ import jetbrains.exodus.entitystore.Entity
 import kotlinx.dnq.*
 import kotlinx.dnq.link.OnDeletePolicy.CASCADE
 import kotlinx.dnq.link.OnDeletePolicy.CLEAR
-import kotlinx.dnq.query.asSequence
 import kotlinx.dnq.query.eq
+import kotlinx.dnq.query.forEach
 import kotlinx.dnq.query.query
+import kotlinx.dnq.query.toList
 import kotlinx.dnq.util.getOldValue
 import kotlinx.dnq.util.isDefined
 import org.junit.Test
@@ -42,9 +43,7 @@ class DestructorTest : DBTest() {
         companion object : XdNaturalEntityType<C1>()
 
         override fun destructor() {
-            C2.query(C2::c1 eq this)
-                    .asSequence()
-                    .forEach { it.c1 = null }
+            C2.query(C2::c1 eq this).forEach { it.c1 = null }
             System.out.println("destructor finished!")
         }
     }

--- a/dnq/src/test/kotlin/kotlinx/dnq/events/ListenersTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/events/ListenersTest.kt
@@ -22,7 +22,6 @@ import kotlinx.dnq.DBTest
 import kotlinx.dnq.XdModel
 import kotlinx.dnq.listener.XdEntityListener
 import kotlinx.dnq.listener.addListener
-import kotlinx.dnq.query.asSequence
 import kotlinx.dnq.query.size
 import kotlinx.dnq.query.toList
 import org.junit.Assert
@@ -195,7 +194,7 @@ class ListenersTest : DBTest() {
         Truth.assertThat(ref.get()).isEqualTo(0)
         Truth.assertThat(
             store.transactional {
-                Foo.all().asSequence().map { it.intField }.all { it == 99 }
+                Foo.all().toList().map { it.intField }.all { it == 99 }
             }
 
         ).isTrue()
@@ -283,7 +282,7 @@ class ListenersTest : DBTest() {
         Truth.assertThat(ref.get()).isEqualTo(4)
         Truth.assertThat(
             store.transactional {
-                Foo.all().asSequence().map { it.intField }.all { it == 11 }
+                Foo.all().toList().map { it.intField }.all { it == 11 }
             }
 
         ).isTrue()
@@ -310,7 +309,7 @@ class ListenersTest : DBTest() {
             }
         }
         transactional {
-            Foo.all().asSequence().forEach { foo->
+            Foo.all().toList().forEach { foo->
                 idToValue[foo.entityId] = foo.intField
             }
         }

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/AsQueryTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/AsQueryTest.kt
@@ -52,7 +52,7 @@ class AsQueryTest : DBTest() {
         }
 
         val user = transactional {
-            val users = XdUser.all().asSequence().filter {
+            val users = XdUser.all().toList().filter {
                 (it.contacts.firstOrNull() as? XdEmail)?.address?.contains("@example.com") == true
             }.map { it.entity }
             users.asIterable().asQuery(XdUser).filter { it.login eq "user_one" }.firstOrNull()

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/MapDistinctTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/MapDistinctTest.kt
@@ -112,6 +112,6 @@ class MapDistinctTest : DBTest() {
 
     private fun <XD : XdEntity> XdQuery<XD>.assertThatSizeIsEqualTo(value: Int) {
         Truth.assertThat(this.size()).isEqualTo(value)
-        Truth.assertThat(this.asSequence().count()).isEqualTo(value)
+        Truth.assertThat(this.toList().count()).isEqualTo(value)
     }
 }

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/ToKotlinCollectionTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/ToKotlinCollectionTest.kt
@@ -38,20 +38,6 @@ class ToKotlinCollectionTest : DBTest() {
     }
 
     @Test
-    fun asIterable() {
-        assertToCollectionOperation {
-            assertThat(it.asIterable())
-        }
-    }
-
-    @Test
-    fun iterator() {
-        assertToCollectionOperation {
-            assertThat(it.iterator().asSequence().toList())
-        }
-    }
-
-    @Test
     fun toCollection() {
         assertToCollectionOperation {
             val destination = LinkedList<Thing>()

--- a/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleApp.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleApp.kt
@@ -33,7 +33,7 @@ class XdUser(entity: Entity) : XdEntity(entity) {
     val contacts by xdChildren0_N(XdContact::owner)
 
     override fun toString(): String {
-        return "$login, ${gender?.presentation ?: "N/A"}, ${contacts.asSequence().joinToString()}"
+        return "$login, ${gender?.presentation ?: "N/A"}, ${contacts.useSequence { it.joinToString() }}"
     }
 }
 
@@ -109,9 +109,7 @@ fun main(args: Array<String>) {
     }
 
     store.transactional {
-        for (contact in user.contacts) {
-            contact.verify()
-        }
+        user.contacts.forEach { it.verify() }
     }
 
     store.transactional(readonly = true) {

--- a/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleShortApp.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleShortApp.kt
@@ -18,7 +18,7 @@ package kotlinx.dnq.sample
 import jetbrains.exodus.entitystore.Entity
 import kotlinx.dnq.*
 import kotlinx.dnq.query.firstOrNull
-import kotlinx.dnq.query.iterator
+import kotlinx.dnq.query.forEach
 import kotlinx.dnq.store.container.StaticStoreContainer
 import kotlinx.dnq.util.initMetaData
 import org.joda.time.DateTime
@@ -78,8 +78,8 @@ fun main(args: Array<String>) {
     // Do in read-only transaction
     xodusStore.transactional(readonly = true) {
         // Print all blog posts
-        for (post in blog.posts) {
-            println("${post.publishedAt}: ${post.text}")
+        blog.posts.forEach {
+            println("${it.publishedAt}: ${it.text}")
         }
     }
 }


### PR DESCRIPTION
Deprecating unsafe methods like `asSequence` or `iterator` from XdQuery, because they cause EntityIterators not being closed/disposed. Instead of them now adding `useSequence` and a bunch of similar methods.