### PR TITLE
XD-1242 Sorted by fix for null values

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinBlock.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinBlock.kt
@@ -18,10 +18,8 @@ package jetbrains.exodus.entitystore.youtrackdb.gremlin
 import com.jetbrains.youtrackdb.api.gremlin.embedded.YTDBVertex
 import com.jetbrains.youtrackdb.api.record.RID
 import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity
-import org.apache.commons.lang3.StringUtils
 import org.apache.tinkerpop.gremlin.process.traversal.Order
 import org.apache.tinkerpop.gremlin.process.traversal.P
-import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import org.apache.tinkerpop.gremlin.process.traversal.TextP
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
@@ -233,8 +231,7 @@ sealed class GremlinBlock(val shortName: String, val type: BlockType) {
     data class HasElement(val property: String, val value: Any) : GremlinBlock("he", BlockType.CONDITION) {
         override fun traverse(g: YT): YT =
             g.where(
-                `__`
-                    .values<YTDBVertex, Any>(property)
+                values<YTDBVertex, Any>(property)
                     .unfold<Any>()
                     .`is`(value)
             )
@@ -310,7 +307,7 @@ sealed class GremlinBlock(val shortName: String, val type: BlockType) {
         ASC, DESC
     }
 
-
+    // Always "nulls last", as the old xodus DNQ implementation worked like this.
     data class Sort(val by: By, val direction: SortDirection) : GremlinBlock("sb", BlockType.ORDER) {
         sealed interface By
         class ByProp(val propName: String) : By
@@ -323,11 +320,24 @@ sealed class GremlinBlock(val shortName: String, val type: BlockType) {
             }
 
             return when (by) {
-                is ByProp -> g.order().by(by.propName, order)
-                is ByLinked -> g.order().by(
-                    `__`.out(YTDBVertexEntity.edgeClassName(by.linkName)).values<Any>(by.propName),
-                    order
-                )
+                is ByProp -> g.order()
+                    .by(values<YTDBVertex, Any>(by.propName).count(), Order.desc)
+                    .by(
+                        `__`.values<YTDBVertex, Any>(by.propName).fold(),
+                        order
+                    )
+
+                is ByLinked -> {
+                    val edgeLabel = YTDBVertexEntity.edgeClassName(by.linkName)
+                    g.order()
+                        .by(`__`.out(edgeLabel).values<Any>(by.propName).count(), Order.desc)
+                        .by(
+                            `__`.out(edgeLabel)
+                                .values<Any>(by.propName)
+                                .fold(),
+                            order
+                        )
+                }
             }
         }
 
@@ -340,10 +350,7 @@ sealed class GremlinBlock(val shortName: String, val type: BlockType) {
         override fun traverse(g: YT): YT =
             g.fold().reverse<Any>().unfold<Any>().asYT()
 
-        override fun describe(s: StringBuilder): StringBuilder {
-            TODO("Not yet implemented")
-        }
-
+        override fun describe(s: StringBuilder): StringBuilder = s.append(".reverse()")
     }
 }
 

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/SortedByTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/SortedByTest.kt
@@ -15,6 +15,7 @@
  */
 package kotlinx.dnq.query
 
+import com.google.common.truth.Truth.assertThat
 import jetbrains.exodus.entitystore.Entity
 import kotlinx.dnq.*
 import org.junit.Before
@@ -27,20 +28,32 @@ class SortedByTest : DBTest() {
 
         var login by xdStringProp()
         var badge by xdLink0_1(Badge)
+        override fun toString(): String {
+            return "User(login=$login, badge=$badge)"
+        }
     }
 
     class Badge(entity: Entity) : XdEntity(entity) {
         companion object : XdNaturalEntityType<Badge>()
 
         var name by xdStringProp()
+        override fun toString(): String {
+            return "Badge(name=$name)"
+        }
     }
 
     val users by lazy {
         transactional {
             listOf(
-                    User.new { login = "2"; badge = Badge.new { name = "c" } },
-                    User.new { login = "3"; badge = Badge.new { name = "b" } },
-                    User.new { login = "1"; badge = Badge.new { name = "a" } }
+                User.new { login = "2"; badge = Badge.new { name = "c" } },
+                User.new { login = "6"; badge = Badge.new { name = null } },
+                User.new { login = "3"; badge = Badge.new { name = "b" } },
+                User.new { login = "1"; badge = Badge.new { name = "a" } },
+                User.new { login = "4"; },
+                User.new {},
+                User.new { login = null },
+                User.new { login = "5"; badge = Badge.new {} }
+
             )
         }
     }
@@ -55,40 +68,51 @@ class SortedByTest : DBTest() {
     }
 
     @Test
-    fun `sort by int property ascending`() {
-        transactional {
-            assertQuery(User.all().sortedBy(User::login, asc = true))
-                    .containsExactlyElementsIn(users.sortedBy { it.login })
-                    .inOrder()
-        }
+    fun `sort by string property ascending`() {
+        checkOrder(
+            "asc",
+            { sortedBy(User::login, asc = true) },
+            compareBy(nullsLast()) { it.login }
+        )
     }
 
     @Test
-    fun `sort by int property descending`() {
-        transactional {
-            assertQuery(User.all().sortedBy(User::login, asc = false))
-                    .containsExactlyElementsIn(users.sortedByDescending { it.login })
-                    .inOrder()
-        }
+    fun `sort by string property descending`() {
+        checkOrder(
+            "desc",
+            { sortedBy(User::login, asc = false) },
+            compareBy(nullsLast(reverseOrder())) { it.login }
+        )
     }
 
     @Test
-    
     fun `sort by property of a link ascending`() {
-        transactional {
-            val query = User.all().sortedBy(User::badge, Badge::name, asc = true)
-            assertQuery(query)
-                    .containsExactlyElementsIn(users.sortedBy { it.badge?.name })
-                    .inOrder()
-        }
+        checkOrder(
+            "linked asc",
+            { sortedBy(User::badge, Badge::name, asc = true) },
+            compareBy(nullsLast()) { it.badge?.name }
+        )
     }
 
     @Test
     fun `sort by property of a link descending`() {
+        checkOrder(
+            "linked desc",
+            { sortedBy(User::badge, Badge::name, asc = false) },
+            compareBy(nullsLast(reverseOrder())) { it.badge?.name }
+        )
+    }
+
+    private fun checkOrder(
+        name: String,
+        queryOrder: XdQuery<User>.() -> XdQuery<User>,
+        expectedOrder: Comparator<User>
+    ) {
         transactional {
-            assertQuery(User.all().sortedBy(User::badge, Badge::name, asc = false))
-                    .containsExactlyElementsIn(users.sortedByDescending { it.badge?.name })
-                    .inOrder()
+            val result = queryOrder(User.all()).toList()
+            println("$name: $result")
+            assertThat(result).containsExactlyElementsIn(users)
+            assertThat(result).isInOrder(expectedOrder)
         }
     }
 }


### PR DESCRIPTION
Fix for Gremlin-based "sorted by" operations:
1. The queries don't ignore null values any more
2. Nulls always go last