### PR TITLE
XD-1248 Collection owned by another entity

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
@@ -187,7 +187,7 @@ open class YTDBVertexEntity(
             is MutableSet<*> -> newValue
             else -> throw IllegalArgumentException("Unexpected value: $newValue")
         }
-        if (set is TrackedMultiValue<*, *> && set.owner == safeVertex { raw() })
+        if (set is TrackedMultiValue<*, *> && set.owner === safeVertex { raw() })
             safeVertex { property(propertyName, set) }
         else if (set.firstOrNull() is Identifiable)
             @Suppress("UNCHECKED_CAST")

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolationTest.kt
@@ -102,9 +102,9 @@ class TransactionsIsolationTest : DBTest() {
             var i = 0
             while (i < cycles) {
                 transactional {
-                    if (i % 1000 == 0) {
-                        println("Check cycle $i")
-                    }
+//                    if (i % 1000 == 0) {
+//                        println("Check cycle $i")
+//                    }
                     val s = sizes
                     if (s[0] == init && s[1] == 0 && s[2] == 0 || s[0] == 0 && s[1] == init && s[2] == 0) {
                         // ok
@@ -127,9 +127,7 @@ class TransactionsIsolationTest : DBTest() {
                     Something.all().toList().forEach {
                         it.sometext = if (a) "bsomething" else "asomething"
                     }
-                    println("Update before flush.")
                     txn.flush()
-                    println("Update after flush.")
                 }
                 a = !a
                 Thread.yield()

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
@@ -230,7 +230,6 @@ class DeleteCycleTest : DBTest() {
         transactional {
             for (i in 0..99) {
                 val d = Driver.query(Driver::age eq i).first()
-                println("Update $d")
                 d.name = d.name?.uppercase()
             }
         }


### PR DESCRIPTION
Fixing the "collection owned by another entity" error. Replacing "==" with instance equals "===", as YouTrackDB checks ownership using exact instance match.