### PR TITLE
XD-1246 Adding back logic that was lost with youtrackdb migration

### DIFF
--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntitiesUpdaterImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntitiesUpdaterImpl.kt
@@ -44,7 +44,7 @@ class TransientEntitiesUpdaterImpl(
     }
 
     private val changes = QueueDecorator<() -> Boolean>()
-    private var replayInProgress = false;
+    private var replayInProgress = false
 
     // we keep this collection to be able to call TransientChangesTracker.entityBeforeRemoved() during
     // transaction replay. This is crucial for generating correct REMOVED events with
@@ -503,7 +503,9 @@ class TransientEntitiesUpdaterImpl(
         if (replayInProgress) {
             throw IllegalStateException("Changes can't be added during changes replay")
         }
-        changes.offer(change)
+        if (session.allowRunnables) {
+            changes.offer(change)
+        }
         return change
     }
 

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
@@ -59,7 +59,7 @@ class TransientSessionImpl(
     private var quietFlush = false
     private var loadedIds: EntityIdSet = EntityIdSetFactory.newSet()
     private val hashCode = (Math.random() * Integer.MAX_VALUE).toInt()
-    private var allowRunnables = true
+    internal var allowRunnables = true
     internal val removedEntitiesData =
         IdentityHashMap<DNQListener<*>, MutableMap<EntityId, RemovedEntityData<*>>>()
 


### PR DESCRIPTION
Apparently, the "allowRunnables" check has been lost during migration to youtrackdb. Bringing it back, it should fix ConcurrentModificationException that we're currently facing.