### PR TITLE
XD-1249 Fixing findOrNew messing up with xd entities cache

### DIFF
--- a/dnq/src/main/kotlin/kotlinx/dnq/XdEntityType.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdEntityType.kt
@@ -39,5 +39,5 @@ abstract class XdEntityType<out T : XdEntity>(val storeContainer: StoreContainer
         }
     }
 
-    open fun wrap(entity: Entity) = entity.toXd<T>()
+    open fun wrap(entity: Entity, ignoreXdCache: Boolean = false) = entity.toXd<T>(ignoreXdCache)
 }

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdExtensions.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdExtensions.kt
@@ -25,6 +25,6 @@ val Entity.wrapper: XdEntity get() = toXd(this)
 @Deprecated("Use toXd() instead. May be removed after 01.09.2017", ReplaceWith("toXd<T>()"))
 fun <T : XdEntity> Entity.wrapper() = XdModel.toXd<T>(this)
 
-fun <T : XdEntity> Entity.toXd() = XdModel.toXd<T>(this)
+fun <T : XdEntity> Entity.toXd(ignoreXdCache: Boolean = false) = XdModel.toXd<T>(this, ignoreXdCache)
 
 val TransientEntityStore.session: TransientStoreSession get() = threadSession ?: throw IllegalStateException("No current transient session.")

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdModel.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdModel.kt
@@ -149,13 +149,13 @@ object XdModel : KLogging() {
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun <T : XdEntity> toXd(entity: Entity): T {
+    fun <T : XdEntity> toXd(entity: Entity, ignoreXdCache: Boolean = false): T {
         // this is hack to support abstract type in XdEntityType.filter {} api
         if (entity is FakeTransientEntity) {
             return entity.toXdHandlingAbstraction()
         }
 
-        if (entity is TransientEntityImpl && !entity.isReadonly /* filter entities created over snapshot transaction */) {
+        if (!ignoreXdCache && entity is TransientEntityImpl && !entity.isReadonly /* filter entities created over snapshot transaction */) {
             toXdCache.tryKey(entity.cacheKey)?.let { cachedValue ->
                 if (cachedValue.entity == entity) {
                     return cachedValue.xdEntity as T
@@ -166,14 +166,15 @@ object XdModel : KLogging() {
         val xdHierarchyNode = getOrThrow(entity.type)
         val entityType = xdHierarchyNode.entityType
         if (entityType is XdNaturalWrapper) {
-            return entityType.naturalWrap(entity).asCached as T
+            val wrapped = entityType.naturalWrap(entity)
+            return (if (ignoreXdCache) wrapped else wrapped.asCached) as T
         }
 
         val entityConstructor = xdHierarchyNode.entityConstructor
                 ?: throw UnsupportedOperationException("Constructor for the type ${entity.type} is not found")
 
-        return entityConstructor(entity).asCached as T
-
+        val wrapped = entityConstructor(entity)
+        return (if (ignoreXdCache) wrapped else wrapped.asCached) as T
     }
 
     fun <T : XdEntity> getCommonAncestor(typeA: XdEntityType<T>, typeB: XdEntityType<T>): XdEntityType<T>? {

--- a/dnq/src/main/kotlin/kotlinx/dnq/creator/XdFindOrNew.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/creator/XdFindOrNew.kt
@@ -24,7 +24,9 @@ import kotlinx.dnq.session
 
 fun <XD : XdEntity> XdEntityType<XD>.findOrNew(findQuery: XdQuery<XD>, initNew: XD.() -> Unit): XD {
     val entityCreator = object : EntityCreator(entityType) {
-        override fun find() = findQuery.firstOrNull()?.entity
+        // we need to ignore XD cache, because during transaction replays
+        // deleted and existing transient entities maybe be mixed up.
+        override fun find() = findQuery.firstOrNull(ignoreXdCache = true)?.entity
 
         override fun created(entity: Entity) {
             wrap(entity).also {

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
@@ -790,7 +790,7 @@ fun <T : XdEntity> XdQuery<T>.first(node: NodeBase): T {
 /**
  * Returns the first result of the query, or `null` if the query is empty.
  */
-fun <T : XdEntity> XdQuery<T>.firstOrNull(): T? {
+fun <T : XdEntity> XdQuery<T>.firstOrNull(ignoreXdCache: Boolean = false): T? {
     if (entityIterable is TransientEntityIterable){
         return useIterable(entityIterable) { eit -> eit.firstOrNull()?.let { entityType.wrap(it) } }
     }
@@ -800,7 +800,7 @@ fun <T : XdEntity> XdQuery<T>.firstOrNull(): T? {
     } else {
         useIterable(it) { eit -> eit.firstOrNull() }
     }
-    return entity?.let { entityType.wrap(it) }
+    return entity?.let { entityType.wrap(it, ignoreXdCache) }
 }
 
 /**

--- a/dnq/src/test/kotlin/kotlinx/dnq/FindOrCreateTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/FindOrCreateTest.kt
@@ -19,8 +19,13 @@ import com.google.common.truth.Truth.assertThat
 import jetbrains.exodus.entitystore.Entity
 import kotlinx.dnq.creator.findOrNew
 import kotlinx.dnq.query.addAll
+import kotlinx.dnq.query.filter
+import kotlinx.dnq.query.toList
 import org.junit.Test
 import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
 import kotlin.concurrent.thread
 
 class FindOrCreateTest : DBTest() {
@@ -54,13 +59,18 @@ class FindOrCreateTest : DBTest() {
         }
     }
 
+    class JustCounter(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<JustCounter>()
+
+        var value by xdRequiredIntProp()
+    }
+
     override fun registerEntityTypes() {
         super.registerEntityTypes()
-        XdModel.registerNode(ApprovedScope)
+        XdModel.registerNodes(ApprovedScope, JustCounter)
     }
 
     @Test
-    
     fun `sequential creation should return the same entity`() {
         val user = store.transactional {
             User.new { login = "zeckson"; skill = 1 }
@@ -122,7 +132,6 @@ class FindOrCreateTest : DBTest() {
     }
 
     @Test
-    
     fun `simple findOrNew`() {
         val user = store.transactional {
             User.new { login = "zeckson"; skill = 1 }
@@ -142,6 +151,59 @@ class FindOrCreateTest : DBTest() {
         store.transactional {
             assertThat(user1).isNotEqualTo(user2)
             assertThat(user2).isEqualTo(user)
+        }
+    }
+
+    @Test
+    fun `findOrNew with replay`() {
+        val counter = transactional { JustCounter.new { value = 0 } }
+
+        val userName = "test findOrNew"
+        val boss = transactional { User.new { login = "supervisor"; skill = 123 } }
+        val user = transactional { User.new {
+            login = userName
+            skill = 123
+            supervisor = boss
+        } }
+
+        val start = CyclicBarrier(2)
+        val end = CountDownLatch(1)
+        val pool = Executors.newFixedThreadPool(2)
+
+        val t1 = pool.submit {
+            transactional {
+                start.await()
+                counter.value += 1
+                user.delete()
+            }
+            transactional {
+                assertThat(User.all().toList()).hasSize(1)
+            }
+            end.countDown()
+        }
+
+        val t2 = pool.submit {
+            transactional {
+                start.await()
+                counter.value += 1
+                User.findOrNew(User.filter { it.login eq userName }) {
+                    println(user)
+                    login = userName
+                    skill = 456
+                    supervisor = boss
+                }
+                end.await()
+            }
+        }
+
+        listOf(t1, t2).forEach { it.get() }
+
+        transactional {
+            val users = User.all().filter { it.login eq userName }.toList()
+
+            assertThat(users).hasSize(1)
+            assertThat(users.first().login).isEqualTo(userName)
+            assertThat(users.first().entityId).isNotEqualTo(user.entityId)
         }
     }
 }


### PR DESCRIPTION
Fixing findOrNew messing up with xd entities cache. See the new `findOrNew with replay` test scenario for more details.