### PR TITLE
XD-1251 Fixing the param count in UnionAll Gremlin step

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
@@ -297,7 +297,7 @@ sealed class GremlinQuery {
         }
 
         override fun continueTraversal(t: YT, paramCounter: Int, ignoreSort: Boolean): YTBuilder {
-            val subi = subtraversals(0, ignoreSort)
+            val subi = subtraversals(paramCounter, ignoreSort)
             return YTBuilder.of(t.union(*subi.first), counter = subi.second)
         }
 

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
@@ -213,6 +213,28 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
     }
 
     @Test
+    fun `intersect with nested intersect`() {
+        val test = givenTestCase()
+
+        withStoreTx {
+            test.issue2.setProperty(Issues.Props.PRIORITY, "normal")
+            test.issue3.setProperty(Issues.Props.PRIORITY, "normal")
+        }
+
+        withStoreTx { tx ->
+            val i1 = tx.find(Issues.CLASS, "name", test.issue1.name())
+            val i2 = tx.find(Issues.CLASS, "name", test.issue2.name())
+            val i2or3 = tx.find(Issues.CLASS, "priority", "normal")
+
+            val i2only = i2.intersect(i2or3)
+            val i1or2 = i1.union(i2only)
+            val i2onlyAgain = i1or2.intersect(i2)
+
+            assertNamesExactly(i2onlyAgain, "issue2")
+        }
+    }
+
+    @Test
     fun `concat iterables selected by properties`() {
         // Given
         val test = givenTestCase()


### PR DESCRIPTION
This fixes passing of the `paramCounter` value in UnionAll down to the subqueries.