### PR TITLE
Update license header year from 2024 to 2026

### DIFF
--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/AsyncListenersReplication.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/AsyncListenersReplication.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/DNQListener.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/DNQListener.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/EntityChangeType.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/EntityChangeType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/EntityCreator.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/EntityCreator.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/EntityStoreRefactorings.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/EntityStoreRefactorings.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/IEntityListener.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/IEntityListener.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/ITransientChangesMultiplexer.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/ITransientChangesMultiplexer.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/LinkChange.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/LinkChange.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/LinkChangeType.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/LinkChangeType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/ListenerInvocationTransport.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/ListenerInvocationTransport.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/ListenerInvocations.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/ListenerInvocations.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientChangesTracker.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientChangesTracker.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntity.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntity.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntityChange.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntityChange.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntityStore.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntityStore.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientStoreSession.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientStoreSession.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientStoreSessionListener.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientStoreSessionListener.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/CantRemoveEntityException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/CantRemoveEntityException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/CardinalityViolationException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/CardinalityViolationException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/ConstraintsValidationException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/ConstraintsValidationException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/DataIntegrityViolationException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/DataIntegrityViolationException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/DatabaseStateIsReadonlyException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/DatabaseStateIsReadonlyException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/EntityFieldHandler.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/EntityFieldHandler.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/EntityRemovedException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/EntityRemovedException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/NullPropertyException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/NullPropertyException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/OrphanChildException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/OrphanChildException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/SimplePropertyValidationException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/SimplePropertyValidationException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/UniqueIndexIntegrityException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/UniqueIndexIntegrityException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/UniqueIndexViolationException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/UniqueIndexViolationException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/UserConstraintValidationException.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/exceptions/UserConstraintValidationException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/AggregationAssociationSemantics.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/AggregationAssociationSemantics.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/AssociationSemantics.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/AssociationSemantics.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/DirectedAssociationSemantics.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/DirectedAssociationSemantics.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/OrderedAssociationSemantics.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/OrderedAssociationSemantics.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/PrimitiveAssociationSemantics.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/PrimitiveAssociationSemantics.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/UndirectedAssociationSemantics.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/association/UndirectedAssociationSemantics.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/AddedOrRemovedLinksFromSetTransientEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/AddedOrRemovedLinksFromSetTransientEntityIterable.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ConstraintsUtil.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ConstraintsUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityIterableWrapper.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityIterableWrapper.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityLifecycle.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityLifecycle.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityMetaDataUtils.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityMetaDataUtils.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityOperations.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityOperations.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/IncomingLinkViolation.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/IncomingLinkViolation.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/MessageBuilder.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/MessageBuilder.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PerEntityIncomingLinkViolation.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PerEntityIncomingLinkViolation.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PerTypeIncomingLinkViolation.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PerTypeIncomingLinkViolation.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIterableWrapper.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIterableWrapper.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIteratorWithPropIdWrapper.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIteratorWithPropIdWrapper.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIteratorWrapper.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIteratorWrapper.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PropertyConstraint.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PropertyConstraint.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadOnlyTransientChangesTrackerImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadOnlyTransientChangesTrackerImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadOnlyTransientSession.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadOnlyTransientSession.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadonlyTransientEntityImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadonlyTransientEntityImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SessionQueryMixin.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SessionQueryMixin.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransactionSizeWarning.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransactionSizeWarning.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransactionSizeWarningMBean.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransactionSizeWarningMBean.kt
@@ -1,5 +1,5 @@
- /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientChangesTrackerImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientChangesTrackerImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterable.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterator.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterator.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityUtil.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSortEngineImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSortEngineImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientStoreUtil.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientStoreUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TxnDiffChangesTracker.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TxnDiffChangesTracker.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/UniversalEmptyEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/UniversalEmptyEntityIterable.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ValidationUtil.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ValidationUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/Internal.kt
+++ b/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/Internal.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/TransientChangesMultiplexer.kt
+++ b/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/TransientChangesMultiplexer.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/Where.kt
+++ b/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/Where.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/constraints/PropertyConstraints.kt
+++ b/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/constraints/PropertyConstraints.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/listeners/ListenerInvocationsImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/listeners/ListenerInvocationsImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/listeners/TransientListenersSerialization.kt
+++ b/dnq-transient-store/src/main/kotlin/jetbrains/exodus/entitystore/listeners/TransientListenersSerialization.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/LinkDelegates.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/LinkDelegates.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/NamedXdEntity.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/NamedXdEntity.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/PropertyDelegates.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/PropertyDelegates.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/RequiredPropertyUndefinedException.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/RequiredPropertyUndefinedException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/Transaction.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/Transaction.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdEntity.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdEntity.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdEntityType.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdEntityType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdEnumEntity.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdEnumEntity.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdEnumEntityType.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdEnumEntityType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdExtensions.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdExtensions.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdModel.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdModel.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdModelPlugin.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdModelPlugin.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdNaturalEntityType.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdNaturalEntityType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdNaturalWrapper.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdNaturalWrapper.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdWrapperNotFoundException.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdWrapperNotFoundException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/creator/XdFindOrNew.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/creator/XdFindOrNew.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/Links.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/Links.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/OnDeletePolicy.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/OnDeletePolicy.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyChildrenToMultiParentLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyChildrenToMultiParentLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyChildrenToParentLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyChildrenToParentLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToManyLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToManyLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToOneOptionalLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToOneOptionalLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToOneRequiredLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToOneRequiredLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneChildToMultiParentLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneChildToMultiParentLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneChildToParentLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneChildToParentLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToManyLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToManyLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToOneOptionalLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToOneOptionalLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToOneRequiredLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToOneRequiredLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToManyChildrenLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToManyChildrenLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToOneOptionalChildLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToOneOptionalChildLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToOneRequiredChildLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToOneRequiredChildLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdToManyLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdToManyLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdToOneOptionalLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdToOneOptionalLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdToOneRequiredLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdToOneRequiredLink.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/listener/ClassBasedXdListenersSerialization.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/listener/ClassBasedXdListenersSerialization.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/listener/XdChangesTrackerMultiplexer.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/listener/XdChangesTrackerMultiplexer.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/listener/XdEntityListener.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/listener/XdEntityListener.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/management/DnqStatistics.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/management/DnqStatistics.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/management/DnqStatisticsMBean.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/management/DnqStatisticsMBean.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/FakeTransientEntities.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/FakeTransientEntities.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/NodeBaseOperations.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/NodeBaseOperations.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdFilteringQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdFilteringQuery.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdMutableQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdMutableQuery.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/sequence/XdSequenceProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/sequence/XdSequenceProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/Factories.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/Factories.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/PrimitiveTypeUtil.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/PrimitiveTypeUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/PropertyConstraints.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/PropertyConstraints.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdBlobProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdBlobProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdConstrainedProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdConstrainedProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdMutableConstrainedProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdMutableConstrainedProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdMutableSetProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdMutableSetProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdNullableBlobProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdNullableBlobProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdNullableProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdNullableProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdNullableTextProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdNullableTextProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdPropertyRequirement.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdPropertyRequirement.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdSetProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdSetProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdTextProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdTextProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/XdWrappedProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/XdWrappedProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/custom/type/XdCustomTypeBinding.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/custom/type/XdCustomTypeBinding.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/custom/type/XdCustomTypeBindingRegistry.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/custom/type/XdCustomTypeBindingRegistry.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/simple/custom/type/XdCustomTypeProperty.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/simple/custom/type/XdCustomTypeProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/singleton/Caches.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/singleton/Caches.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/singleton/XdSingletonEntitiesCache.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/singleton/XdSingletonEntitiesCache.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/singleton/XdSingletonEntityType.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/singleton/XdSingletonEntityType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/EntityLifecycleImpl.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/EntityLifecycleImpl.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/XdQueryEngine.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/XdQueryEngine.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/container/EntityStoreHelper.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/container/EntityStoreHelper.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/container/StaticStoreContainer.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/container/StaticStoreContainer.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/container/StoreContainer.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/container/StoreContainer.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/container/ThreadLocalStoreContainer.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/container/ThreadLocalStoreContainer.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/DNQMetaDataUtil.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/DNQMetaDataUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/FakeEntity.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/FakeEntity.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/Ids.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/Ids.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/ReflectionUtil.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/ReflectionUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/TransientEntityUtil.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/TransientEntityUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/Types.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/Types.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/XdHierarchyNode.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/XdHierarchyNode.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/XdPropertyCachedProvider.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/XdPropertyCachedProvider.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/AbstractRelationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/AbstractRelationTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/AnnihilationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/AnnihilationTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/AssociationSimpleTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/AssociationSimpleTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/AsyncTransactionUtil.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/AsyncTransactionUtil.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/AutoMergeTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/AutoMergeTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/CompositeIndexTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/CompositeIndexTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/CountTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/CountTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/CreateTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/CreateTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/DBNameTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DBNameTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/DBTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DBTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DeleteTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/DestroyTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DestroyTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/DisposeCursorTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DisposeCursorTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/EnumTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/EnumTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/EqualsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/EqualsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/ExtensionLinksTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/ExtensionLinksTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/FindOrCreateTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/FindOrCreateTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/GetOldLinkTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/GetOldLinkTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/GetSafeTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/GetSafeTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/HasChangesTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/HasChangesTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/InitEntityTypeTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/InitEntityTypeTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/IsDefinedTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/IsDefinedTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/LinksTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/LinksTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/LinksTypeTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/LinksTypeTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/MultiParentTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/MultiParentTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/MutableSetPropertyTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/MutableSetPropertyTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/PropertiesTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/PropertiesTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/PropertyConstraintsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/PropertyConstraintsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/ReflectionUtilTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/ReflectionUtilTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/SearchByPropertyTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/SearchByPropertyTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/SequenceTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/SequenceTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/SetPropertyTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/SetPropertyTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/SingletonTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/SingletonTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/ThreadLocalStoreContainerTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/ThreadLocalStoreContainerTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/ToIdFromIdTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/ToIdFromIdTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransactionSizeWarningTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransactionSizeWarningTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityLinksFromSetTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityLinksFromSetTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityLinksTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityLinksTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/TriggersTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TriggersTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/TypeExtensionsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TypeExtensionsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/XdHierarchyTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/XdHierarchyTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/beforeFlush/BeforeFlushTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/beforeFlush/BeforeFlushTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/blob/BlobTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/blob/BlobTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/ConcurrentAggregationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/ConcurrentAggregationTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/DirectedAssociationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/DirectedAssociationTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/UndirectedAssociationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/UndirectedAssociationTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/SnapshotIsolationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/SnapshotIsolationTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TinyConcurrentStressTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TinyConcurrentStressTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolation2Test.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolation2Test.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/TransactionsIsolationTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/customConstraints/CustomConstraintsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/customConstraints/CustomConstraintsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/CascadeChildTreeDeletionTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/CascadeChildTreeDeletionTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/CascadeRemoveTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/CascadeRemoveTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/DestructorTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/DestructorTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/IsRemovedTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/IsRemovedTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/Model.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/Model.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/OldValueTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/OldValueTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/OrphansAutoRemoveTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/OrphansAutoRemoveTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/RemoveTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/RemoveTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/RemovedEntityTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/RemovedEntityTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/RemovedSavedNewTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/RemovedSavedNewTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/SophisticatedTargetDeleteTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/SophisticatedTargetDeleteTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/events/CompareInsideListenerTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/events/CompareInsideListenerTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/events/EventsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/events/EventsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/events/ListenersTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/events/ListenersTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/events/Model.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/events/Model.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/incomingLinks/IncomingLinksConstraintsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/incomingLinks/IncomingLinksConstraintsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/AssociationConstraintsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/AssociationConstraintsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnDeleteConstraintTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnDeleteConstraintTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnTargetDeleteCascadeTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnTargetDeleteCascadeTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnTargetDeleteClearTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnTargetDeleteClearTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnTargetDeleteConstraintTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/linkConstraints/OnTargetDeleteConstraintTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/BinaryOperationsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/BinaryOperationsTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/DateQueriesTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/DateQueriesTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/FilterAndMapWithAbstractClassesTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/FilterAndMapWithAbstractClassesTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/FilterIsInstanceTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/FilterIsInstanceTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryAndOrTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryAndOrTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryDecoratedTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryDecoratedTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryLinksTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryLinksTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryPropertiesTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/FilterQueryPropertiesTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/IsInQueryTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/IsInQueryTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/MapDistinctTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/MapDistinctTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/QueryAddAllTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/QueryAddAllTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/QueryRemoveAllTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/QueryRemoveAllTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/QueryTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/QueryTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/SizeTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/SizeTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/SortedByTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/SortedByTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/ToKotlinCollectionTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/ToKotlinCollectionTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/sample/MultiStoreSample.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/sample/MultiStoreSample.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleApp.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleApp.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleShortApp.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/sample/SampleShortApp.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/InstantProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/InstantProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/LocalDateProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/LocalDateProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/LocalDateTimeProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/LocalDateTimeProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/LocalTimeProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/LocalTimeProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/OffsetDateTimeProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/OffsetDateTimeProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/OffsetTimeProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/OffsetTimeProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/TimeConstraints.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/TimeConstraints.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/ZoneOffsetProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/ZoneOffsetProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/ZonedDateTimeProperty.kt
+++ b/java-8-time/src/main/kotlin/kotlinx/dnq/java/time/ZonedDateTimeProperty.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/OptionalTimePropertyTest.kt
+++ b/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/OptionalTimePropertyTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/RequiredTimePropertyTest.kt
+++ b/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/RequiredTimePropertyTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/TimePropertiesQueryTest.kt
+++ b/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/TimePropertiesQueryTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/TimePropertiesTestData.kt
+++ b/java-8-time/src/test/kotlin/kotlinx/dnq/java/time/TimePropertiesTestData.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006 - 2024 JetBrains s.r.o.
+ * Copyright 2006 - 2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Update copyright year in license headers from 2024 to 2026 across all source files
- Applied via `./gradlew licenseFormat` — the template in `license/copyright.ftl` uses `Calendar.getInstance().get(Calendar.YEAR)`, so every file was stale

## Test plan
- [x] `./gradlew licenseFormat` ran successfully
- [ ] Verify `./gradlew license` passes (header consistency check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)