### PR TITLE
Update Kotlin to 2.2.21, JDK to 21, Gradle to 8.8

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'io.morethan.jmhreport' version "0.1.0"
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = 21
 
 dependencies {
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '2.2.21'
     ext.exodus_version = '3.0.86'
-    ext.dokka_version = '1.7.20'
+    ext.dokka_version = '1.9.20'
     ext.log4j_version = '2.17.1'
     ext.google_truth_version = '1.1.3'
     ext.junit_version = '4.13.2'
@@ -22,7 +22,7 @@ plugins {
 
 idea {
     project {
-        jdkName = '11'
+        jdkName = '21'
         vcs = 'Git'
     }
     module {
@@ -43,7 +43,7 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(11))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 }
@@ -57,7 +57,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(11))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 
@@ -87,9 +87,7 @@ subprojects {
 
     tasks.withType(compileKotlin.class).all {
         kotlinOptions {
-            jvmTarget = "11"
-            apiVersion = "1.8"
-            languageVersion = "1.8"
+            jvmTarget = "21"
         }
     }
 

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteCycleTest.kt
@@ -231,7 +231,7 @@ class DeleteCycleTest : DBTest() {
             for (i in 0..99) {
                 val d = Driver.query(Driver::age eq i).first()
                 println("Update $d")
-                d.name = d.name?.toUpperCase()
+                d.name = d.name?.uppercase()
             }
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Update Kotlin from 1.8.10 to 2.2.21
- Update JDK target from 11 to 21 (toolchain, jvmTarget, IDE config)
- Update Gradle wrapper from 7.6.1 to 8.8
- Update Dokka from 1.7.20 to 1.9.20
- Fix deprecated `toUpperCase()` → `uppercase()` in DeleteCycleTest

Aligns xodus-dnq build toolchain versions with YouTrack.

## Test plan
- [x] `./gradlew build` passes (all modules compile and tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)