### PR TITLE
XD-1266 Add non-polymorphic query support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 
 # virtual machine crash logs
 hs_err_pid*
+/.claude/

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransaction.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransaction.kt
@@ -91,7 +91,10 @@ interface YTDBStoreTransaction : StoreTransaction {
 
     override fun getSnapshot(): YTDBStoreTransaction
 
-    override fun getAll(entityType: String): YTDBEntityIterable
+    override fun getAll(entityType: String): YTDBEntityIterable =
+        getAll(entityType, polymorphic = true)
+
+    fun getAll(entityType: String, polymorphic: Boolean): YTDBEntityIterable
 
     override fun getSingletonIterable(entity: Entity): YTDBEntityIterable
 
@@ -99,6 +102,13 @@ interface YTDBStoreTransaction : StoreTransaction {
         entityType: String,
         propertyName: String,
         value: Comparable<*>
+    ): YTDBEntityIterable = find(entityType, propertyName, value, polymorphic = true)
+
+    fun find(
+        entityType: String,
+        propertyName: String,
+        value: Comparable<*>,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun find(
@@ -106,6 +116,14 @@ interface YTDBStoreTransaction : StoreTransaction {
         propertyName: String,
         minValue: Comparable<*>,
         maxValue: Comparable<*>
+    ): YTDBEntityIterable = find(entityType, propertyName, minValue, maxValue, polymorphic = true)
+
+    fun find(
+        entityType: String,
+        propertyName: String,
+        minValue: Comparable<*>,
+        maxValue: Comparable<*>,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findContaining(
@@ -113,51 +131,106 @@ interface YTDBStoreTransaction : StoreTransaction {
         propertyName: String,
         value: String,
         ignoreCase: Boolean
+    ): YTDBEntityIterable = findContaining(entityType, propertyName, value, ignoreCase, polymorphic = true)
+
+    fun findContaining(
+        entityType: String,
+        propertyName: String,
+        value: String,
+        ignoreCase: Boolean,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findStartingWith(
         entityType: String,
         propertyName: String,
         value: String
+    ): YTDBEntityIterable = findStartingWith(entityType, propertyName, value, polymorphic = true)
+
+    fun findStartingWith(
+        entityType: String,
+        propertyName: String,
+        value: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findIds(
         entityType: String,
         minValue: Long,
         maxValue: Long
+    ): YTDBEntityIterable = findIds(entityType, minValue, maxValue, polymorphic = true)
+
+    fun findIds(
+        entityType: String,
+        minValue: Long,
+        maxValue: Long,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findWithProp(
         entityType: String,
         propertyName: String
+    ): YTDBEntityIterable = findWithProp(entityType, propertyName, polymorphic = true)
+
+    fun findWithProp(
+        entityType: String,
+        propertyName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findWithPropSortedByValue(
         entityType: String,
         propertyName: String
+    ): YTDBEntityIterable = findWithPropSortedByValue(entityType, propertyName, polymorphic = true)
+
+    fun findWithPropSortedByValue(
+        entityType: String,
+        propertyName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findWithBlob(
         entityType: String,
         blobName: String
+    ): YTDBEntityIterable = findWithBlob(entityType, blobName, polymorphic = true)
+
+    fun findWithBlob(
+        entityType: String,
+        blobName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findLinks(
         entityType: String,
         entity: Entity,
         linkName: String
+    ): YTDBEntityIterable = findLinks(entityType, entity, linkName, polymorphic = true)
+
+    fun findLinks(
+        entityType: String,
+        entity: Entity,
+        linkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     fun findLinks(
         entityType: String,
         entityId: YTDBEntityId,
-        linkName: String
+        linkName: String,
+        polymorphic: Boolean = true
     ): YTDBEntityIterable
 
     override fun findLinks(
         entityType: String,
         entities: EntityIterable,
         linkName: String
+    ): YTDBEntityIterable = findLinks(entityType, entities, linkName, polymorphic = true)
+
+    fun findLinks(
+        entityType: String,
+        entities: EntityIterable,
+        linkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     /**
@@ -165,11 +238,21 @@ interface YTDBStoreTransaction : StoreTransaction {
      * regardless of the source entity type. Unlike [findLinks], no `HasLabel` filter
      * is applied, so a single DB traversal covers all source types.
      */
-    fun findLinksUntyped(entity: Entity, linkName: String): YTDBEntityIterable
+    fun findLinksUntyped(
+        entity: Entity,
+        linkName: String,
+        polymorphic: Boolean = true
+    ): YTDBEntityIterable
 
     override fun findWithLinks(
         entityType: String,
         linkName: String
+    ): YTDBEntityIterable = findWithLinks(entityType, linkName, polymorphic = true)
+
+    fun findWithLinks(
+        entityType: String,
+        linkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun findWithLinks(
@@ -177,12 +260,27 @@ interface YTDBStoreTransaction : StoreTransaction {
         linkName: String,
         oppositeEntityType: String,
         oppositeLinkName: String
+    ): YTDBEntityIterable = findWithLinks(entityType, linkName, oppositeEntityType, oppositeLinkName, polymorphic = true)
+
+    fun findWithLinks(
+        entityType: String,
+        linkName: String,
+        oppositeEntityType: String,
+        oppositeLinkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun sort(
         entityType: String,
         propertyName: String,
         ascending: Boolean
+    ): YTDBEntityIterable = sort(entityType, propertyName, ascending, polymorphic = true)
+
+    fun sort(
+        entityType: String,
+        propertyName: String,
+        ascending: Boolean,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun sort(
@@ -190,6 +288,14 @@ interface YTDBStoreTransaction : StoreTransaction {
         propertyName: String,
         rightOrder: EntityIterable,
         ascending: Boolean
+    ): YTDBEntityIterable = sort(entityType, propertyName, rightOrder, ascending, polymorphic = true)
+
+    fun sort(
+        entityType: String,
+        propertyName: String,
+        rightOrder: EntityIterable,
+        ascending: Boolean,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun sortLinks(
@@ -198,6 +304,16 @@ interface YTDBStoreTransaction : StoreTransaction {
         isMultiple: Boolean,
         linkName: String,
         rightOrder: EntityIterable
+    ): YTDBEntityIterable =
+        sortLinks(entityType, sortedLinks, isMultiple, linkName, rightOrder, polymorphic = true)
+
+    fun sortLinks(
+        entityType: String,
+        sortedLinks: EntityIterable,
+        isMultiple: Boolean,
+        linkName: String,
+        rightOrder: EntityIterable,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun sortLinks(
@@ -208,6 +324,18 @@ interface YTDBStoreTransaction : StoreTransaction {
         rightOrder: EntityIterable,
         oppositeEntityType: String,
         oppositeLinkName: String
+    ): YTDBEntityIterable =
+        sortLinks(entityType, sortedLinks, isMultiple, linkName, rightOrder, oppositeEntityType, oppositeLinkName, polymorphic = true)
+
+    fun sortLinks(
+        entityType: String,
+        sortedLinks: EntityIterable,
+        isMultiple: Boolean,
+        linkName: String,
+        rightOrder: EntityIterable,
+        oppositeEntityType: String,
+        oppositeLinkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable
 
     override fun toEntityId(representation: String): YTDBEntityId

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
@@ -255,9 +255,9 @@ class YTDBStoreTransactionImpl(
             .map { it.name }
     }
 
-    override fun getAll(entityType: String): YTDBEntityIterable {
+    override fun getAll(entityType: String, polymorphic: Boolean): YTDBEntityIterable {
         requireActiveTransaction()
-        return YTDBEntityIterable.where(entityType, this, GremlinBlock.All)
+        return YTDBEntityIterable.where(entityType, this, GremlinBlock.All, polymorphic)
     }
 
     override fun getSingletonIterable(entity: Entity): YTDBEntityIterable {
@@ -268,23 +268,26 @@ class YTDBStoreTransactionImpl(
     override fun find(
         entityType: String,
         propertyName: String,
-        value: Comparable<Nothing>
+        value: Comparable<*>,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
-        return YTDBEntityIterable.where(entityType, this, GremlinBlock.PropEqual(propertyName, value))
+        return YTDBEntityIterable.where(entityType, this, GremlinBlock.PropEqual(propertyName, value), polymorphic)
     }
 
     override fun find(
         entityType: String,
         propertyName: String,
-        minValue: Comparable<Nothing>,
-        maxValue: Comparable<Nothing>
+        minValue: Comparable<*>,
+        maxValue: Comparable<*>,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.where(
             entityType,
             this,
-            GremlinBlock.PropInRange(propertyName, minValue, maxValue)
+            GremlinBlock.PropInRange(propertyName, minValue, maxValue),
+            polymorphic
         )
     }
 
@@ -292,7 +295,8 @@ class YTDBStoreTransactionImpl(
         entityType: String,
         propertyName: String,
         value: String,
-        ignoreCase: Boolean
+        ignoreCase: Boolean,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.where(
@@ -304,14 +308,16 @@ class YTDBStoreTransactionImpl(
                 value,
                 isCollection = false,
                 caseSensitive = !ignoreCase
-            )
+            ),
+            polymorphic
         )
     }
 
     override fun findStartingWith(
         entityType: String,
         propertyName: String,
-        value: String
+        value: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.where(
@@ -323,27 +329,30 @@ class YTDBStoreTransactionImpl(
                 value,
                 isCollection = false,
                 caseSensitive = false
-            )
+            ),
+            polymorphic
         )
     }
 
-    override fun findIds(entityType: String, minValue: Long, maxValue: Long): YTDBEntityIterable {
+    override fun findIds(entityType: String, minValue: Long, maxValue: Long, polymorphic: Boolean): YTDBEntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.where(
             entityType,
             this,
-            GremlinBlock.PropInRange(LOCAL_ENTITY_ID_PROPERTY_NAME, minValue, maxValue)
+            GremlinBlock.PropInRange(LOCAL_ENTITY_ID_PROPERTY_NAME, minValue, maxValue),
+            polymorphic
         )
     }
 
-    override fun findWithProp(entityType: String, propertyName: String): YTDBEntityIterable {
+    override fun findWithProp(entityType: String, propertyName: String, polymorphic: Boolean): YTDBEntityIterable {
         requireActiveTransaction()
-        return YTDBEntityIterable.where(entityType, this, GremlinBlock.PropNotNull(propertyName))
+        return YTDBEntityIterable.where(entityType, this, GremlinBlock.PropNotNull(propertyName), polymorphic)
     }
 
     override fun findWithPropSortedByValue(
         entityType: String,
-        propertyName: String
+        propertyName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.query(
@@ -352,75 +361,94 @@ class YTDBStoreTransactionImpl(
                 .then(GremlinBlock.HasLabel(entityType))
                 .then(GremlinBlock.PropNotNull(propertyName))
                 // todo: move SortBy out of Condition
-                .then(GremlinBlock.Sort(GremlinBlock.Sort.ByProp(propertyName), SortDirection.ASC))
+                .then(GremlinBlock.Sort(GremlinBlock.Sort.ByProp(propertyName), SortDirection.ASC)),
+            polymorphic
         )
     }
 
-    override fun findWithBlob(entityType: String, blobName: String): YTDBEntityIterable {
-        return findWithProp(entityType, blobName)
+    override fun findWithBlob(entityType: String, blobName: String, polymorphic: Boolean): YTDBEntityIterable {
+        return findWithProp(entityType, blobName, polymorphic)
     }
 
-    override fun findLinks(entityType: String, entityId: YTDBEntityId, linkName: String): YTDBEntityIterable {
+    override fun findLinks(
+        entityType: String,
+        entityId: YTDBEntityId,
+        linkName: String,
+        polymorphic: Boolean
+    ): YTDBEntityIterable {
         requireActiveTransaction()
-
         return YTDBEntityIterable.query(
             this,
             GremlinQuery
                 .ByIds(listOf(entityId.asOId()))
                 .then(GremlinBlock.InLink(linkName))
-                .then(GremlinBlock.HasLabel(entityType))
+                .then(GremlinBlock.HasLabel(entityType)),
+            polymorphic
         )
     }
 
-    override fun findLinks(entityType: String, entity: Entity, linkName: String): YTDBEntityIterable {
-        return findLinks(entityType, entity.id as YTDBEntityId, linkName)
+    override fun findLinks(
+        entityType: String,
+        entity: Entity,
+        linkName: String,
+        polymorphic: Boolean
+    ): YTDBEntityIterable {
+        return findLinks(entityType, entity.id as YTDBEntityId, linkName, polymorphic)
     }
 
-    override fun findLinksUntyped(entity: Entity, linkName: String): YTDBEntityIterable {
+    override fun findLinksUntyped(
+        entity: Entity,
+        linkName: String,
+        polymorphic: Boolean
+    ): YTDBEntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.query(
             this,
             GremlinQuery
                 .ByIds(listOf((entity.id as YTDBEntityId).asOId()))
-                .then(GremlinBlock.InLink(linkName))
+                .then(GremlinBlock.InLink(linkName)),
+            polymorphic
         )
     }
 
     override fun findLinks(
         entityType: String,
         entities: EntityIterable,
-        linkName: String
+        linkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
-
         return if (entities === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
         else YTDBEntityIterable.query(
             this,
             entities.asYTDBIterable().query
                 .then(GremlinBlock.InLink(linkName))
-                .then(GremlinBlock.HasLabel(entityType))
+                .then(GremlinBlock.HasLabel(entityType)),
+            polymorphic
         )
     }
 
-    override fun findWithLinks(entityType: String, linkName: String): YTDBEntityIterable {
+    override fun findWithLinks(entityType: String, linkName: String, polymorphic: Boolean): YTDBEntityIterable {
         requireActiveTransaction()
-        return YTDBEntityIterable.where(entityType, this, GremlinBlock.HasLink(linkName))
+        return YTDBEntityIterable.where(entityType, this, GremlinBlock.HasLink(linkName), polymorphic)
     }
 
     override fun findWithLinks(
         entityType: String,
         linkName: String,
         oppositeEntityType: String,
-        oppositeLinkName: String
+        oppositeLinkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
-        return YTDBEntityIterable.where(entityType, this, GremlinBlock.HasLink(linkName))
+        return YTDBEntityIterable.where(entityType, this, GremlinBlock.HasLink(linkName), polymorphic)
     }
 
     override fun sort(
         entityType: String,
         propertyName: String,
-        ascending: Boolean
+        ascending: Boolean,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.query(
@@ -432,7 +460,8 @@ class YTDBStoreTransactionImpl(
                         GremlinBlock.Sort.ByProp(propertyName),
                         if (ascending) SortDirection.ASC else SortDirection.DESC
                     )
-                )
+                ),
+            polymorphic
         )
     }
 
@@ -440,10 +469,10 @@ class YTDBStoreTransactionImpl(
         entityType: String,
         propertyName: String,
         rightOrder: EntityIterable,
-        ascending: Boolean
+        ascending: Boolean,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
-
         return if (rightOrder === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
         else YTDBEntityIterableImpl(
             this,
@@ -453,7 +482,8 @@ class YTDBStoreTransactionImpl(
                         GremlinBlock.Sort.ByProp(propertyName),
                         if (ascending) SortDirection.ASC else SortDirection.DESC
                     )
-                )
+                ),
+            polymorphic
         )
     }
 
@@ -461,7 +491,8 @@ class YTDBStoreTransactionImpl(
         entityType: String,
         linkName: String,
         propertyName: String,
-        ascending: Boolean
+        ascending: Boolean,
+        polymorphic: Boolean = true
     ): EntityIterable {
         requireActiveTransaction()
         return YTDBEntityIterable.query(
@@ -473,7 +504,8 @@ class YTDBStoreTransactionImpl(
                         GremlinBlock.Sort.ByLinked(linkName, propertyName),
                         if (ascending) SortDirection.ASC else SortDirection.DESC
                     )
-                )
+                ),
+            polymorphic
         )
     }
 
@@ -482,10 +514,11 @@ class YTDBStoreTransactionImpl(
         linkName: String,
         propertyName: String,
         rightOrder: EntityIterable,
-        ascending: Boolean
+        ascending: Boolean,
+        polymorphic: Boolean = true
     ): EntityIterable {
         requireActiveTransaction()
-        return if (rightOrder === YTDBEntityIterable.EMPTY) return YTDBEntityIterable.EMPTY
+        return if (rightOrder === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
         else YTDBEntityIterableImpl(
             this,
             rightOrder.asYTDBIterable().query
@@ -494,7 +527,8 @@ class YTDBStoreTransactionImpl(
                         GremlinBlock.Sort.ByLinked(linkName, propertyName),
                         if (ascending) SortDirection.ASC else SortDirection.DESC
                     )
-                )
+                ),
+            polymorphic
         )
     }
 
@@ -503,7 +537,8 @@ class YTDBStoreTransactionImpl(
         sortedLinks: EntityIterable,
         isMultiple: Boolean,
         linkName: String,
-        rightOrder: EntityIterable
+        rightOrder: EntityIterable,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
         return if (rightOrder === YTDBEntityIterable.EMPTY || sortedLinks === YTDBEntityIterable.EMPTY)
@@ -513,7 +548,8 @@ class YTDBStoreTransactionImpl(
             sortedLinks.asYTDBIterable().query
                 .then(GremlinBlock.InLink(linkName))
                 .intersect(rightOrder.asYTDBIterable().query)
-                .then(GremlinBlock.HasLabel(entityType))
+                .then(GremlinBlock.HasLabel(entityType)),
+            polymorphic
         )
     }
 
@@ -524,7 +560,8 @@ class YTDBStoreTransactionImpl(
         linkName: String,
         rightOrder: EntityIterable,
         oppositeEntityType: String,
-        oppositeLinkName: String
+        oppositeLinkName: String,
+        polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
         // todo: check if we need this
@@ -536,7 +573,8 @@ class YTDBStoreTransactionImpl(
             sortedLinks.asYTDBIterable().query
                 .then(GremlinBlock.InLink(linkName))
                 .intersect(rightOrder.asYTDBIterable().query)
-                .then(GremlinBlock.HasLabel(entityType))
+                .then(GremlinBlock.HasLabel(entityType)),
+            polymorphic
         )
     }
 
@@ -578,7 +616,7 @@ class YTDBStoreTransactionImpl(
         val session = activeYtdbSession()
         // make sure the OSequence created
         schemaBuddy.getOrCreateSequence(session, sequenceName, initialValue)
-        return YTDBSequence(session as DatabaseSessionEmbedded, sequenceName, store)
+        return YTDBSequence(session, sequenceName, store)
     }
 
     override fun getOSequence(sequenceName: String): DBSequence {

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
@@ -19,9 +19,11 @@ import com.jetbrains.youtrackdb.api.gremlin.embedded.YTDBVertex
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock.SortDirection
 import org.apache.tinkerpop.gremlin.process.traversal.P
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy
 
 sealed class GremlinQuery {
 
@@ -263,11 +265,36 @@ sealed class GremlinQuery {
 
     data class UnionAll(val subqueries: List<GremlinQuery>) : GremlinQuery() {
 
-        private fun subtraversals(counter: Int, sortApplied: Boolean): Pair<Array<YT>, Int> {
+        /**
+         * Creates anonymous child traversals for each subquery.
+         *
+         * When [optionsStrategy] is provided, it is added to each anonymous child traversal.
+         * This propagates query-level config (e.g. `polymorphicQuery`) so that provider
+         * optimization strategies (such as `YTDBGraphStepStrategy`) can read it when they
+         * are applied to the child traversal.
+         *
+         * Only [OptionsStrategy] is propagated — not the full strategy list — to avoid
+         * interfering with TinkerPop's own strategy application on child traversals.
+         * The graph reference is not needed: TinkerPop propagates it automatically when
+         * the child traversal is integrated into the parent via `union()`.
+         *
+         * `GraphTraversal.with()` cannot be used here: it is a step modulator (configures
+         * the preceding step), not traversal-wide config. Anonymous traversals need the
+         * [OptionsStrategy] set directly via the admin API.
+         */
+        private fun subtraversals(
+            optionsStrategy: OptionsStrategy?,
+            counter: Int,
+            sortApplied: Boolean
+        ): Pair<Array<YT>, Int> {
             val result = mutableListOf<YT>()
             var c = counter
             subqueries.forEach { sq ->
-                val subRes = sq.continueTraversal(`__`.start(), c, sortApplied)
+                val child = `__`.start<Any>()
+                if (optionsStrategy != null) {
+                    child.asAdmin().strategies.addStrategies(optionsStrategy)
+                }
+                val subRes = sq.continueTraversal(child.asYT(), c, sortApplied)
                 c = subRes.counter
                 result.add(subRes.traversal)
             }
@@ -275,13 +302,20 @@ sealed class GremlinQuery {
             return Pair(result.toTypedArray(), c)
         }
 
+        private fun extractOptionsStrategy(strategies: TraversalStrategies): OptionsStrategy? =
+            strategies.getStrategy(OptionsStrategy::class.java).orElse(null)
+
         override fun startTraversal(gs: GraphTraversalSource): YTBuilder {
-            val subi = subtraversals(0, sortApplied = false)
+            val subi = subtraversals(extractOptionsStrategy(gs.strategies), 0, sortApplied = false)
             return YTBuilder.of(gs.union(*subi.first), counter = subi.second)
         }
 
         override fun continueTraversal(t: YT, paramCounter: Int, ignoreSort: Boolean): YTBuilder {
-            val subi = subtraversals(paramCounter, ignoreSort)
+            val subi = subtraversals(
+                extractOptionsStrategy(t.asAdmin().strategies),
+                paramCounter,
+                ignoreSort
+            )
             return YTBuilder.of(t.union(*subi.first), counter = subi.second)
         }
 

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQueryOptimizer.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQueryOptimizer.kt
@@ -15,7 +15,6 @@
  */
 package jetbrains.exodus.entitystore.youtrackdb.gremlin
 
-import com.jetbrains.youtrackdb.internal.core.db.record.record.RID
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery.*
 
 private fun extractLabel(q: GremlinQuery): String? = if (q is Labeled) q.label else null
@@ -47,7 +46,7 @@ private fun extractLabel(q: GremlinQuery): String? = if (q is Labeled) q.label e
 private fun extractCondition(q: GremlinQuery): GremlinBlock? =
     if (q is Labeled && q.inner is Condition) q.inner.asBlock()
     else if (q is Labeled && q.inner is Labeled && q.inner.inner is Condition &&
-             (q.inner.inner as Condition).asBlock() is GremlinBlock.All)
+             q.inner.inner.asBlock() is GremlinBlock.All)
         GremlinBlock.HasLabel(q.inner.label)
     else if (q is Condition) q.asBlock()
     else null
@@ -363,7 +362,7 @@ internal fun GremlinQuery.combineEfficient(
         fun mergeHomogeneousFL(union: UnionAll): FollowLink? {
             val first = union.subqueries.firstOrNull() as? FollowLink ?: return null
             if (union.subqueries.any { it !is FollowLink ||
-                    (it as FollowLink).direction != first.direction ||
+                    it.direction != first.direction ||
                     it.linkName != first.linkName }) return null
             val mergedInner = union.subqueries.drop(1).fold(first.inner) { acc, q ->
                 acc.union((q as FollowLink).inner)
@@ -378,8 +377,17 @@ internal fun GremlinQuery.combineEfficient(
             }
             val condBlock = extractCondition(this)
             if (condBlock != null) {
+                // O20b-fix: re-apply the label from `this` (if present) after distributing
+                // the condition into branches. extractCondition strips the Labeled wrapper,
+                // losing the hasLabel filter. Wrapping the result re-applies hasLabel after
+                // the union — at a different traversal level, so TinkerPop's
+                // InlineFilterStrategy won't merge it with branch-level hasLabel steps.
+                // When a label is present, omit Dedup here — O17 (the caller that stripped
+                // Order(Dedup) before recursing) will re-wrap the result with Dedup.
+                val label = extractLabel(this)
                 val branches = other.subqueries.map { it.then(condBlock) }
-                return UnionAll(branches).then(GremlinBlock.Dedup)
+                return if (label != null) Labeled.of(UnionAll(branches), label)
+                       else UnionAll(branches).then(GremlinBlock.Dedup)
             }
         }
         if (this is UnionAll && this.subqueries.none { hasPaging(it) }) {
@@ -390,8 +398,11 @@ internal fun GremlinQuery.combineEfficient(
             }
             val condBlock = extractCondition(other)
             if (condBlock != null) {
+                // O20b-fix: same label preservation as the symmetric path above.
+                val label = extractLabel(other)
                 val branches = this.subqueries.map { it.then(condBlock) }
-                return UnionAll(branches).then(GremlinBlock.Dedup)
+                return if (label != null) Labeled.of(UnionAll(branches), label)
+                       else UnionAll(branches).then(GremlinBlock.Dedup)
             }
         }
     }
@@ -476,7 +487,7 @@ internal fun GremlinQuery.combineEfficient(
             if (innerFL != null) {
                 val innerSrcCondBlock = extractCondition(innerFL.inner)
                 if (innerSrcCondBlock != null) {
-                    val srcLabel = (flInner.inner as Labeled).label
+                    val srcLabel = flInner.inner.label
                     val innerSrcLabel = extractLabel(innerFL.inner)
                     val outerLinkStep = if (flInner.direction == LinkDirection.IN)
                         GremlinBlock.OutLink(flInner.linkName)

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
@@ -16,6 +16,7 @@
 package jetbrains.exodus.entitystore.youtrackdb.iterate
 
 import com.jetbrains.youtrackdb.api.gremlin.embedded.YTDBVertex
+import com.jetbrains.youtrackdb.api.gremlin.tokens.YTDBQueryConfigParam
 import jetbrains.exodus.entitystore.Entity
 import jetbrains.exodus.entitystore.EntityId
 import jetbrains.exodus.entitystore.EntityIterable
@@ -35,17 +36,25 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 interface YTDBEntityIterable : EntityIterable {
     companion object {
         @JvmStatic
-        fun where(entityType: String, tx: YTDBStoreTransaction, condition: GremlinBlock): YTDBEntityIterable =
+        @JvmOverloads
+        fun where(
+            entityType: String,
+            tx: YTDBStoreTransaction,
+            condition: GremlinBlock,
+            polymorphic: Boolean = true
+        ): YTDBEntityIterable =
             query(
                 tx,
                 GremlinQuery.all
                     .then(condition)
-                    .then(GremlinBlock.HasLabel(entityType))
+                    .then(GremlinBlock.HasLabel(entityType)),
+                polymorphic
             )
 
         @JvmStatic
-        fun query(tx: YTDBStoreTransaction, query: GremlinQuery) =
-            YTDBEntityIterableImpl(tx, query)
+        @JvmOverloads
+        fun query(tx: YTDBStoreTransaction, query: GremlinQuery, polymorphic: Boolean = true) =
+            YTDBEntityIterableImpl(tx, query, polymorphic)
 
         @JvmStatic
         fun empty() = EMPTY
@@ -96,6 +105,8 @@ interface YTDBEntityIterable : EntityIterable {
 
     val query: GremlinQuery
 
+    val polymorphic: Boolean get() = true
+
     fun traversal(): GraphTraversal<*, YTDBVertex>
 
     fun idSet(): EntityIdSet = this.fold(EntityIdSetFactory.newSet()) { acc, e -> acc.add(e.id) }
@@ -103,7 +114,8 @@ interface YTDBEntityIterable : EntityIterable {
 
 class YTDBEntityIterableImpl(
     private val tx: YTDBStoreTransaction,
-    override val query: GremlinQuery
+    override val query: GremlinQuery,
+    override val polymorphic: Boolean = true
 ) : YTDBEntityIterable {
 
     private val oStore: YTDBEntityStore = tx.getStore()
@@ -112,13 +124,16 @@ class YTDBEntityIterableImpl(
     private var cachedSize: Long = -1
 
     private fun modify(block: GremlinBlock): YTDBEntityIterableImpl =
-        YTDBEntityIterableImpl(tx, this.query.then(block))
+        YTDBEntityIterableImpl(tx, this.query.then(block), polymorphic)
 
     private fun iterator(traversal: GraphTraversal<*, YTDBVertex>): YTDBEntityIterator =
         YTDBEntityIterator.of(traversal, oStore)
 
-    override fun traversal(): GraphTraversal<*, YTDBVertex> =
-        query.start(oStore.requireActiveTransaction().g())
+    override fun traversal(): GraphTraversal<*, YTDBVertex> {
+        val gs = oStore.requireActiveTransaction().g()
+            .with(YTDBQueryConfigParam.polymorphicQuery, polymorphic)
+        return query.start(gs)
+    }
 
     override fun iterator(): YTDBEntityIterator = iterator(traversal())
 
@@ -170,21 +185,45 @@ class YTDBEntityIterableImpl(
 
     override fun intersect(right: EntityIterable): EntityIterable =
         if (right === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
-        else YTDBEntityIterableImpl(tx, query.intersect(right.asYTDBIterable().query))
+        else {
+            val rightIterable = right.asYTDBIterable()
+            requirePolymorphicMatch(rightIterable)
+            YTDBEntityIterableImpl(tx, query.intersect(rightIterable.query), polymorphic)
+        }
 
     override fun intersectSavingOrder(right: EntityIterable): EntityIterable = intersect(right)
 
     override fun union(right: EntityIterable): EntityIterable =
         if (right === YTDBEntityIterable.EMPTY) this
-        else YTDBEntityIterableImpl(tx, query.union(right.asYTDBIterable().query))
+        else {
+            val rightIterable = right.asYTDBIterable()
+            requirePolymorphicMatch(rightIterable)
+            YTDBEntityIterableImpl(tx, query.union(rightIterable.query), polymorphic)
+        }
 
     override fun minus(right: EntityIterable): EntityIterable =
         if (right === YTDBEntityIterable.EMPTY) this
-        else YTDBEntityIterableImpl(tx, query.difference(right.asYTDBIterable().query))
+        else {
+            val rightIterable = right.asYTDBIterable()
+            requirePolymorphicMatch(rightIterable)
+            YTDBEntityIterableImpl(tx, query.difference(rightIterable.query), polymorphic)
+        }
 
     override fun concat(right: EntityIterable): EntityIterable =
         if (right === YTDBEntityIterable.EMPTY) this
-        else YTDBEntityIterableImpl(tx, query.unionAll(right.asYTDBIterable().query))
+        else {
+            val rightIterable = right.asYTDBIterable()
+            requirePolymorphicMatch(rightIterable)
+            YTDBEntityIterableImpl(tx, query.unionAll(rightIterable.query), polymorphic)
+        }
+
+    private fun requirePolymorphicMatch(right: YTDBEntityIterable) {
+        require(polymorphic == right.polymorphic) {
+            "Cannot combine a ${if (polymorphic) "polymorphic" else "non-polymorphic"} iterable " +
+                    "with a ${if (right.polymorphic) "polymorphic" else "non-polymorphic"} one. " +
+                    "Both operands must have the same polymorphic flag."
+        }
+    }
 
     override fun skip(number: Int): EntityIterable =
         if (number == 0) this
@@ -205,7 +244,8 @@ class YTDBEntityIterableImpl(
                 this.query,
                 GremlinQuery.LinkDirection.OUT,
                 linkName,
-            )
+            ),
+            polymorphic
         )
 
     override fun selectManyDistinct(linkName: String): EntityIterable =
@@ -234,13 +274,14 @@ class YTDBEntityIterableImpl(
         linkName: String
     ): EntityIterable =
         if (entities === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
-        else YTDBEntityIterableImpl(
-            this.tx,
-            entities
-                .asYTDBIterable()
-                .query
-                .then(GremlinBlock.InLink(linkName))
-        ).distinct()
+        else {
+            val entitiesIterable = entities.asYTDBIterable()
+            YTDBEntityIterableImpl(
+                this.tx,
+                entitiesIterable.query.then(GremlinBlock.InLink(linkName)),
+                entitiesIterable.polymorphic
+            ).distinct()
+        }
 
     override fun idSet(): EntityIdSet =
         this.fold(EntityIdSetFactory.newSet()) { acc, e -> acc.add(e.id) }

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionPolymorphicTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionPolymorphicTest.kt
@@ -1,0 +1,517 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.exodus.entitystore.youtrackdb
+
+import jetbrains.exodus.entitystore.youtrackdb.testutil.*
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class YTDBStoreTransactionPolymorphicTest : OTestMixin {
+
+    @Rule
+    @JvmField
+    val orientDbRule = InMemoryYouTrackDB(initializeIssueSchema = false)
+
+    override val youTrackDb = orientDbRule
+
+    private fun givenUserHierarchy() {
+        youTrackDb.withSession { session ->
+            val baseClass = session.getOrCreateVertexClass(BaseUser.CLASS)
+            listOf(
+                session.getOrCreateVertexClass(User.CLASS),
+                session.getOrCreateVertexClass(Guest.CLASS)
+            ).forEach { it.addSuperClass(baseClass) }
+        }
+        withStoreTx { tx ->
+            tx.createUser(BaseUser.CLASS, "base1").also {
+                it.setProperty("age", 30)
+            }
+            tx.createUser(User.CLASS, "user1").also {
+                it.setProperty("age", 25)
+            }
+            tx.createUser(Guest.CLASS, "guest1").also {
+                it.setProperty("age", 20)
+            }
+        }
+    }
+
+    @Test
+    fun `non-polymorphic getAll returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.getAll(BaseUser.CLASS, polymorphic = false)
+            assertNamesExactly(result, "base1")
+        }
+    }
+
+    @Test
+    fun `default getAll returns all subtypes`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.getAll(BaseUser.CLASS)
+            assertNamesExactly(result, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic find by property returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            // find with exact value
+            val result = tx.find(BaseUser.CLASS, "age", 30, polymorphic = false)
+            assertNamesExactly(result, "base1")
+
+            // age=25 belongs to User subtype — non-polymorphic must exclude it
+            val subtypeValue = tx.find(BaseUser.CLASS, "age", 25, polymorphic = false)
+            assertNamesExactly(subtypeValue)
+
+            // Polymorphic find matches across subtypes
+            val polyResult = tx.find(BaseUser.CLASS, "age", 25)
+            assertNamesExactly(polyResult, "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic find range returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.find(BaseUser.CLASS, "age", 0, 100, polymorphic = false)
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.find(BaseUser.CLASS, "age", 0, 100)
+            assertNamesExactly(polyResult, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findWithProp returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.findWithProp(BaseUser.CLASS, "name", polymorphic = false)
+            assertNamesExactly(result, "base1")
+        }
+    }
+
+    @Test
+    fun `default findWithProp returns all subtypes`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.findWithProp(BaseUser.CLASS, "name")
+            assertNamesExactly(result, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findContaining returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            // "1" matches all entity names — non-polymorphic should still return only BaseUser
+            val result = tx.findContaining(
+                BaseUser.CLASS, "name", "1", false, polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findContaining(BaseUser.CLASS, "name", "1", false)
+            assertNamesExactly(polyResult, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findStartingWith returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            // Empty prefix matches all names — non-polymorphic should still return only BaseUser
+            val result = tx.findStartingWith(BaseUser.CLASS, "name", "", polymorphic = false)
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findStartingWith(BaseUser.CLASS, "name", "")
+            assertNamesExactly(polyResult, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findWithBlob delegates to findWithProp`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.findWithBlob(BaseUser.CLASS, "name", polymorphic = false)
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findWithBlob(BaseUser.CLASS, "name")
+            assertNamesExactly(polyResult, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findWithLinks returns exact type only`() {
+        youTrackDb.withSession { session ->
+            val baseClass = session.getOrCreateVertexClass(BaseUser.CLASS)
+            listOf(
+                session.getOrCreateVertexClass(User.CLASS),
+                session.getOrCreateVertexClass(Guest.CLASS)
+            ).forEach { it.addSuperClass(baseClass) }
+            session.getOrCreateVertexClass("Target")
+        }
+        withStoreTx { tx ->
+            val base = tx.createUser(BaseUser.CLASS, "base1")
+            val user = tx.createUser(User.CLASS, "user1")
+            val target = tx.newEntity("Target")
+            base.addLink("friend", target)
+            user.addLink("friend", target)
+        }
+
+        withStoreTx { tx ->
+            val result = tx.findWithLinks(BaseUser.CLASS, "friend", polymorphic = false)
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findWithLinks(BaseUser.CLASS, "friend")
+            assertNamesExactly(polyResult, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findIds returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.findIds(
+                BaseUser.CLASS, Long.MIN_VALUE, Long.MAX_VALUE, polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findIds(BaseUser.CLASS, Long.MIN_VALUE, Long.MAX_VALUE)
+            assertNamesExactly(polyResult, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findWithLinks 4-arg returns exact type only`() {
+        youTrackDb.withSession { session ->
+            val baseClass = session.getOrCreateVertexClass(BaseUser.CLASS)
+            listOf(
+                session.getOrCreateVertexClass(User.CLASS),
+                session.getOrCreateVertexClass(Guest.CLASS)
+            ).forEach { it.addSuperClass(baseClass) }
+            session.getOrCreateVertexClass("Target")
+        }
+        withStoreTx { tx ->
+            val base = tx.createUser(BaseUser.CLASS, "base1")
+            val user = tx.createUser(User.CLASS, "user1")
+            val target = tx.newEntity("Target")
+            base.addLink("friend", target)
+            user.addLink("friend", target)
+            target.addLink("friendOf", base)
+            target.addLink("friendOf", user)
+        }
+
+        withStoreTx { tx ->
+            val result = tx.findWithLinks(
+                BaseUser.CLASS, "friend", "Target", "friendOf",
+                polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findWithLinks(
+                BaseUser.CLASS, "friend", "Target", "friendOf"
+            )
+            assertNamesExactly(polyResult, "base1", "user1")
+        }
+    }
+
+    // --- Step 2: query()-based and direct constructor methods ---
+
+    @Test
+    fun `non-polymorphic findLinks by entityId returns exact type only`() {
+        givenUserHierarchyWithLinks()
+
+        withStoreTx { tx ->
+            val target = tx.find(BaseUser.CLASS, "name", "base1").first()
+            val targetId = target.id as YTDBEntityId
+
+            val result = tx.findLinks(
+                BaseUser.CLASS, targetId, "friend", polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findLinks(BaseUser.CLASS, targetId, "friend")
+            assertNamesExactly(polyResult, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findLinks by entity returns exact type only`() {
+        givenUserHierarchyWithLinks()
+
+        withStoreTx { tx ->
+            val target = tx.find(BaseUser.CLASS, "name", "base1").first()
+
+            val result = tx.findLinks(
+                BaseUser.CLASS, target, "friend", polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findLinks(BaseUser.CLASS, target, "friend")
+            assertNamesExactly(polyResult, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic sort returns exact type only sorted`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.sort(
+                BaseUser.CLASS, "age", true, polymorphic = false
+            )
+            assertNamesExactlyInOrder(result, "base1")
+
+            val polyResult = tx.sort(BaseUser.CLASS, "age", true)
+            assertNamesExactlyInOrder(polyResult, "guest1", "user1", "base1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic sort with rightOrder uses method polymorphic parameter`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            // rightOrder contains all BaseUser subtypes (polymorphic=true)
+            val rightOrder = tx.getAll(BaseUser.CLASS)
+
+            // But the sort method's own polymorphic=false should control the output
+            val result = tx.sort(
+                BaseUser.CLASS, "age", rightOrder, true, polymorphic = false
+            )
+            assertNamesExactlyInOrder(result, "base1")
+
+            val polyResult = tx.sort(BaseUser.CLASS, "age", rightOrder, true)
+            assertNamesExactlyInOrder(polyResult, "guest1", "user1", "base1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findWithPropSortedByValue returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = tx.findWithPropSortedByValue(
+                BaseUser.CLASS, "name", polymorphic = false
+            )
+            assertNamesExactlyInOrder(result, "base1")
+
+            val polyResult = tx.findWithPropSortedByValue(BaseUser.CLASS, "name")
+            assertNamesExactlyInOrder(polyResult, "base1", "guest1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic findLinks by entities returns exact type only`() {
+        givenUserHierarchyWithLinks()
+
+        withStoreTx { tx ->
+            val targets = tx.find(BaseUser.CLASS, "name", "base1")
+
+            val result = tx.findLinks(
+                BaseUser.CLASS, targets, "friend", polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.findLinks(BaseUser.CLASS, targets, "friend")
+            assertNamesExactly(polyResult, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `findLinksUntyped polymorphic flag does not affect results (no HasLabel)`() {
+        givenUserHierarchyWithLinks()
+
+        withStoreTx { tx ->
+            val target = tx.find(BaseUser.CLASS, "name", "base1").first()
+
+            // findLinksUntyped has no HasLabel, so both flags produce identical results.
+            // The flag exists for API consistency and downstream combination validation.
+            val nonPoly = tx.findLinksUntyped(target, "friend", polymorphic = false)
+            assertNamesExactly(nonPoly, "base1", "user1")
+
+            val poly = tx.findLinksUntyped(target, "friend")
+            assertNamesExactly(poly, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic sortLinks returns exact type only`() {
+        givenUserHierarchyWithLinks()
+
+        withStoreTx { tx ->
+            // sortedLinks: targets of the "friend" link (base1)
+            val sortedLinks = tx.find(BaseUser.CLASS, "name", "base1")
+            val rightOrder = tx.getAll(BaseUser.CLASS)
+
+            // InLink("friend") from base1 → [base1, user1], intersect with rightOrder,
+            // HasLabel(BaseUser, polymorphic=false) → base1 only
+            val result = tx.sortLinks(
+                BaseUser.CLASS, sortedLinks, false, "friend", rightOrder,
+                polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.sortLinks(
+                BaseUser.CLASS, sortedLinks, false, "friend", rightOrder
+            )
+            assertNamesExactly(polyResult, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic sortLinks 7-arg returns exact type only`() {
+        givenUserHierarchyWithLinks()
+
+        withStoreTx { tx ->
+            val sortedLinks = tx.find(BaseUser.CLASS, "name", "base1")
+            val rightOrder = tx.getAll(BaseUser.CLASS)
+
+            val result = tx.sortLinks(
+                BaseUser.CLASS, sortedLinks, false, "friend", rightOrder,
+                BaseUser.CLASS, "friend", polymorphic = false
+            )
+            assertNamesExactly(result, "base1")
+
+            val polyResult = tx.sortLinks(
+                BaseUser.CLASS, sortedLinks, false, "friend", rightOrder,
+                BaseUser.CLASS, "friend"
+            )
+            assertNamesExactly(polyResult, "base1", "user1")
+        }
+    }
+
+    // --- Combination of tx-level results ---
+
+    @Test
+    fun `non-polymorphic getAll union across types returns exact-type instances`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = tx.getAll(BaseUser.CLASS, polymorphic = false)
+            val nonPolyUser = tx.getAll(User.CLASS, polymorphic = false)
+
+            // All ∪ All with different labels → UnionAll (Track 5 path)
+            // Non-poly: [base1] ∪ [user1] = [base1, user1]
+            // Poly leak on BaseUser would add user1+guest1
+            val result = nonPolyBase.union(nonPolyUser)
+            assertNamesExactly(result, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic getAll intersect find returns exact-type instances`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val allBase = tx.getAll(BaseUser.CLASS, polymorphic = false)
+            val findBase = tx.find(BaseUser.CLASS, "age", 30, polymorphic = false)
+
+            // All ∩ PropEqual, same label → fused Where
+            // Non-poly: [base1] ∩ [base1(age=30)] = [base1]
+            val result = allBase.intersect(findBase)
+            assertNamesExactly(result, "base1")
+
+            // Poly leak: getAll(BaseUser) would return [base1,user1,guest1],
+            // find(BaseUser,age=30) would also match base1(30) only → [base1]
+            // Not falsifiable on intersect alone, so also verify the union:
+            val polyBase = tx.getAll(BaseUser.CLASS)
+            val polyFind = tx.find(BaseUser.CLASS, "age", 25)
+            // Poly: [base1,user1,guest1] ∩ [user1(age=25)] = [user1]
+            assertNamesExactly(polyBase.intersect(polyFind), "user1")
+            // Non-poly: [base1] ∩ [](age=25 belongs to User) = []
+            val nonPolyFind25 = tx.find(BaseUser.CLASS, "age", 25, polymorphic = false)
+            assertNamesExactly(allBase.intersect(nonPolyFind25))
+        }
+    }
+
+    @Test
+    fun `non-polymorphic find minus getAll cross-type returns correct result`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            // find(BaseUser, age in [0,100], non-poly) → [base1]
+            val findRange = tx.find(BaseUser.CLASS, "age", 0, 100, polymorphic = false)
+            // getAll(User, non-poly) → [user1]
+            val allUser = tx.getAll(User.CLASS, polymorphic = false)
+
+            // [base1] \ [user1] = [base1] (disjoint)
+            // Poly leak on findRange: [base1,user1,guest1] \ [user1] = [base1,guest1]
+            val result = findRange.minus(allUser)
+            assertNamesExactly(result, "base1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic getAll concat returns exact-type instances in order`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = tx.getAll(BaseUser.CLASS, polymorphic = false)
+            val nonPolyGuest = tx.getAll(Guest.CLASS, polymorphic = false)
+
+            // [base1] ++ [guest1] = [base1, guest1]
+            // Poly leak on BaseUser: [base1,user1,guest1] ++ [guest1] = 4 results
+            val result = nonPolyBase.concat(nonPolyGuest)
+            assertNamesExactlyInOrder(result, "base1", "guest1")
+        }
+    }
+
+    @Test
+    fun `mixing polymorphic and non-polymorphic tx results throws on combination`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = tx.getAll(BaseUser.CLASS)
+            val nonPoly = tx.getAll(BaseUser.CLASS, polymorphic = false)
+
+            assertFailsWith<IllegalArgumentException> { poly.union(nonPoly) }
+            assertFailsWith<IllegalArgumentException> { nonPoly.intersect(poly) }
+            assertFailsWith<IllegalArgumentException> { poly.minus(nonPoly) }
+            assertFailsWith<IllegalArgumentException> { nonPoly.concat(poly) }
+        }
+    }
+
+    private fun givenUserHierarchyWithLinks() {
+        youTrackDb.withSession { session ->
+            val baseClass = session.getOrCreateVertexClass(BaseUser.CLASS)
+            listOf(
+                session.getOrCreateVertexClass(User.CLASS),
+                session.getOrCreateVertexClass(Guest.CLASS)
+            ).forEach { it.addSuperClass(baseClass) }
+        }
+        withStoreTx { tx ->
+            val base = tx.createUser(BaseUser.CLASS, "base1")
+            val user = tx.createUser(User.CLASS, "user1")
+            tx.createUser(Guest.CLASS, "guest1")
+            // Both base and user link to base1 (self-referencing for base, cross-type for user)
+            base.addLink("friend", base)
+            user.addLink("friend", base)
+        }
+    }
+}

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
@@ -1176,10 +1176,17 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
         }
     }
 
-    private fun gremlinOf(iterable: YTDBEntityIterable): String =
-        GroovyTranslator.of("g")
+    private fun gremlinOf(iterable: YTDBEntityIterable): String {
+        val script = GroovyTranslator.of("g")
             .translate(iterable.traversal().asAdmin().bytecode)
             .script
+        // Strip the polymorphicQuery traversal source config to keep tests focused on
+        // query algebra. Polymorphic flag behavior is tested separately.
+        return script.replaceFirst(
+            Regex("""^g\.withStrategies\(new OptionsStrategy\(polymorphicQuery: (true|false)\)\)\."""),
+            "g."
+        )
+    }
 
     private fun checkGremlin(iterable: YTDBEntityIterable, expectedGremlin: String) {
         assertEquals(expectedGremlin, gremlinOf(iterable))

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBPolymorphicQueryTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBPolymorphicQueryTest.kt
@@ -1,0 +1,571 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.exodus.entitystore.youtrackdb.iterate
+
+import com.google.common.truth.Truth.assertThat
+import jetbrains.exodus.entitystore.youtrackdb.getOrCreateVertexClass
+import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
+import jetbrains.exodus.entitystore.youtrackdb.testutil.*
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class YTDBPolymorphicQueryTest : OTestMixin {
+
+    @Rule
+    @JvmField
+    val orientDbRule = InMemoryYouTrackDB(initializeIssueSchema = false)
+
+    override val youTrackDb = orientDbRule
+
+    private fun givenUserHierarchy() {
+        youTrackDb.withSession { session ->
+            val baseClass = session.getOrCreateVertexClass(BaseUser.CLASS)
+            listOf(
+                session.getOrCreateVertexClass(User.CLASS),
+                session.getOrCreateVertexClass(Guest.CLASS)
+            ).forEach { it.addSuperClass(baseClass) }
+        }
+        withStoreTx { tx ->
+            tx.createUser(BaseUser.CLASS, "base1")
+            tx.createUser(User.CLASS, "user1")
+            tx.createUser(Guest.CLASS, "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic getAll returns exact type only`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            assertNamesExactly(result, "base1")
+        }
+    }
+
+    @Test
+    fun `polymorphic getAll returns subclasses (default)`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val result = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All)
+
+            assertNamesExactly(result, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `flag survives single-operand chaining`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val afterSkip = nonPoly.skip(1) as YTDBEntityIterable
+            assertFalse(afterSkip.polymorphic)
+            // Non-poly BaseUser=[base1], skip(1)=[] ; poly leak would give [user1, guest1]
+            assertNamesExactly(afterSkip)
+
+            val afterTake = nonPoly.take(10) as YTDBEntityIterable
+            assertFalse(afterTake.polymorphic)
+            assertNamesExactly(afterTake, "base1")
+
+            val afterDistinct = nonPoly.distinct() as YTDBEntityIterable
+            assertFalse(afterDistinct.polymorphic)
+
+            val afterReverse = nonPoly.reverse() as YTDBEntityIterable
+            assertFalse(afterReverse.polymorphic)
+            // Non-poly BaseUser=[base1], reverse=[base1] ; poly leak would give 3 results
+            assertNamesExactly(afterReverse, "base1")
+        }
+    }
+
+    @Test
+    fun `flag survives combination methods`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly1 = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPoly2 = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val intersected = nonPoly1.intersect(nonPoly2) as YTDBEntityIterable
+            assertFalse(intersected.polymorphic)
+            // End-to-end: disjoint types produce empty intersection
+            assertEquals(0, intersected.count())
+
+            val unioned = nonPoly1.union(nonPoly2) as YTDBEntityIterable
+            assertFalse(unioned.polymorphic)
+            // Non-poly: [base1] ∪ [user1] = [base1, user1] ; poly leak on BaseUser would add guest1
+            assertNamesExactly(unioned, "base1", "user1")
+
+            val minused = nonPoly1.minus(nonPoly2) as YTDBEntityIterable
+            assertFalse(minused.polymorphic)
+            // End-to-end: minus of disjoint non-polymorphic iterables preserves left operand results
+            assertNamesExactly(minused, "base1")
+
+            val concatenated = nonPoly1.concat(nonPoly2) as YTDBEntityIterable
+            assertFalse(concatenated.polymorphic)
+            // Non-poly: [base1] ++ [user1] = [base1, user1] ; poly leak would give 4 results
+            assertNamesExactlyInOrder(concatenated, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `flag propagates through selectMany`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val selected = nonPoly.selectMany("someLink") as YTDBEntityIterable
+            assertFalse(selected.polymorphic)
+        }
+    }
+
+    @Test
+    fun `default polymorphic flag is true`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All)
+
+            assertTrue(poly.polymorphic)
+        }
+    }
+
+    @Test
+    fun `non-polymorphic query on leaf type returns same results as polymorphic`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPoly = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            assertNamesExactly(poly, "user1")
+            assertNamesExactly(nonPoly, "user1")
+        }
+    }
+
+    @Test
+    fun `findLinks propagates polymorphic flag from entities parameter`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val polyReceiver = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPolyEntities = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val result = polyReceiver.findLinks(nonPolyEntities, "someLink") as YTDBEntityIterable
+            assertFalse(result.polymorphic, "findLinks should propagate entities-parameter flag, not receiver flag")
+        }
+    }
+
+    @Test
+    fun `flag preserved when combining with EMPTY`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val empty = YTDBEntityIterable.EMPTY
+
+            assertFalse((nonPoly.union(empty) as YTDBEntityIterable).polymorphic)
+            assertFalse((nonPoly.minus(empty) as YTDBEntityIterable).polymorphic)
+            assertFalse((nonPoly.concat(empty) as YTDBEntityIterable).polymorphic)
+            // intersect with EMPTY returns EMPTY itself (acceptable: empty result)
+            assertSame(nonPoly.intersect(empty), YTDBEntityIterable.EMPTY)
+        }
+    }
+
+    @Test
+    fun `non-polymorphic distinct returns exact-type results end-to-end`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // distinct() goes through modify(), producing a new iterable;
+            // verify the flag propagates AND the traversal respects it
+            assertNamesExactly(nonPoly.distinct(), "base1")
+        }
+    }
+
+    // --- UnionAll traversal propagation tests ---
+
+    @Test
+    fun `non-polymorphic union of inherited types returns only exact-type instances`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            // BaseUser is parent of User — these types have an inheritance relationship.
+            // Each non-polymorphic query should return only exact instances of its type:
+            //   BaseUser → ["base1"], User → ["user1"]
+            // Their union should return exactly ["base1", "user1"] — NOT "guest1".
+            // If the engine makes this polymorphic, BaseUser would also match user1+guest1.
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val unioned = nonPolyBase.union(nonPolyUser)
+            assertNamesExactly(unioned, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic concat of inherited types returns only exact-type instances`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val concatenated = nonPolyBase.concat(nonPolyUser)
+            assertNamesExactlyInOrder(concatenated, "base1", "user1")
+        }
+    }
+
+    @Test
+    fun `nested concat propagates non-polymorphic flag through inner UnionAll`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            // A.concat(B).concat(C) creates UnionAll([UnionAll([A,B]), C]).
+            // The inner UnionAll's continueTraversal receives an anonymous traversal
+            // that had OptionsStrategy added by the outer subtraversals(). Without the
+            // Track 5 fix (propagating OptionsStrategy to child traversals),
+            // the inner children would lose the polymorphicQuery config.
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyGuest = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val nested = nonPolyBase.concat(nonPolyUser).concat(nonPolyGuest)
+            assertNamesExactlyInOrder(nested, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic union then concat triggers continueTraversal on inner UnionAll`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyGuest = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // A.union(B) produces Order(UnionAll([A,B]), Dedup).
+            // concat does NOT flatten, so .concat(C) produces:
+            //   UnionAll([Order(UnionAll([A,B]), Dedup), C])
+            // The outer UnionAll.startTraversal propagates OptionsStrategy to child traversals.
+            // Order.continueTraversal delegates to UnionAll.continueTraversal, which must
+            // extract OptionsStrategy from the parent traversal's admin interface.
+            // If continueTraversal fails to propagate: BaseUser(poly) returns {base1,user1,guest1},
+            // User(poly) returns {user1,guest1}, union dedup → {base1,user1,guest1},
+            // concat Guest(non-poly) → [base1,user1,guest1,guest1] (4 results, not 3).
+            val result = nonPolyBase.union(nonPolyUser).concat(nonPolyGuest)
+            assertNamesExactlyInOrder(result, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic union then minus excludes subtypes from parent`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyGuest = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // (User ∪ Guest) \ BaseUser
+            // Non-poly: ({user1} ∪ {guest1}) \ {base1} = {user1, guest1} (disjoint)
+            // If poly leaked on BaseUser: \ {base1,user1,guest1} = empty
+            val result = nonPolyUser.union(nonPolyGuest).minus(nonPolyBase)
+            assertNamesExactly(result, "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic union then intersect with parent type returns empty`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyGuest = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // (User ∪ Guest) ∩ BaseUser
+            // Non-poly: ({user1} ∪ {guest1}) ∩ {base1} = empty (disjoint)
+            // If poly leaked on BaseUser: ∩ {base1,user1,guest1} = {user1, guest1}
+            // The optimizer distributes via O20b and re-applies the label (O20b-fix).
+            val result = nonPolyUser.union(nonPolyGuest).intersect(nonPolyBase)
+            assertEquals(0, result.count())
+        }
+    }
+
+    @Test
+    fun `non-polymorphic minus then union preserves exact-type semantics`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyGuest = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // (BaseUser \ Guest) ∪ User
+            // Non-poly: ({base1} \ {guest1}) ∪ {user1} = {base1} ∪ {user1} = {base1, user1}
+            // If poly leaked on BaseUser: ({base1,user1,guest1} \ {guest1}) ∪ {user1}
+            //   = {base1, user1} ∪ {user1} = {base1, user1} — same result (not falsifiable).
+            // Use reverse operands to make it falsifiable:
+            // (User \ BaseUser) ∪ Guest
+            // Non-poly: ({user1} \ {base1}) ∪ {guest1} = {user1, guest1}
+            // If poly leaked on BaseUser: ({user1} \ {base1,user1,guest1}) ∪ {guest1}
+            //   = {} ∪ {guest1} = {guest1}
+            val result = nonPolyUser.minus(nonPolyBase).union(nonPolyGuest)
+            assertNamesExactly(result, "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic intersect then union returns correct result`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyGuest = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // (BaseUser ∩ User) ∪ Guest = ["guest1"]
+            // BaseUser is ["base1"], User is ["user1"] — disjoint, so intersect is empty.
+            val result = nonPolyBase.intersect(nonPolyUser).union(nonPolyGuest)
+            assertNamesExactly(result, "guest1")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic union then selectMany propagates flag`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // No entities have "someLink" links, so we only verify flag propagation.
+            val unioned = nonPolyBase.union(nonPolyUser) as YTDBEntityIterable
+            val selected = unioned.selectMany("someLink") as YTDBEntityIterable
+            assertFalse(selected.polymorphic, "selectMany on union result should propagate non-polymorphic flag")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic union as findLinks entities parameter propagates flag from entities`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            // Receiver is polymorphic — different from the entities parameter.
+            val polyReceiver = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = true)
+
+            // findLinks propagates the flag from the entities parameter (the union),
+            // not from the receiver. No entities have "someLink" links.
+            val unioned = nonPolyBase.union(nonPolyUser)
+            val found = polyReceiver.findLinks(unioned, "someLink") as YTDBEntityIterable
+            assertFalse(found.polymorphic, "findLinks should propagate flag from union entities parameter, not receiver")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic union then single-operand chain returns correct results`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPolyBase = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPolyUser = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            // (BaseUser ∪ User).take(10).distinct()
+            val result = nonPolyBase.union(nonPolyUser).take(10).distinct()
+            assertNamesExactly(result, "base1", "user1")
+        }
+    }
+
+    // --- Combination flag validation tests ---
+
+    @Test
+    fun `mixed-flag intersect throws in both directions with descriptive message`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val ex1 = assertFailsWith<IllegalArgumentException> { poly.intersect(nonPoly) }
+            assertTrue(ex1.message!!.startsWith("Cannot combine a polymorphic iterable with a non-polymorphic"))
+
+            val ex2 = assertFailsWith<IllegalArgumentException> { nonPoly.intersect(poly) }
+            assertTrue(ex2.message!!.startsWith("Cannot combine a non-polymorphic iterable with a polymorphic"))
+        }
+    }
+
+    @Test
+    fun `mixed-flag union throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val ex1 = assertFailsWith<IllegalArgumentException> { poly.union(nonPoly) }
+            assertTrue(ex1.message!!.contains("polymorphic flag"))
+            val ex2 = assertFailsWith<IllegalArgumentException> { nonPoly.union(poly) }
+            assertTrue(ex2.message!!.contains("polymorphic flag"))
+        }
+    }
+
+    @Test
+    fun `mixed-flag minus throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val ex1 = assertFailsWith<IllegalArgumentException> { poly.minus(nonPoly) }
+            assertTrue(ex1.message!!.contains("polymorphic flag"))
+            val ex2 = assertFailsWith<IllegalArgumentException> { nonPoly.minus(poly) }
+            assertTrue(ex2.message!!.contains("polymorphic flag"))
+        }
+    }
+
+    @Test
+    fun `mixed-flag concat throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val ex1 = assertFailsWith<IllegalArgumentException> { poly.concat(nonPoly) }
+            assertTrue(ex1.message!!.contains("polymorphic flag"))
+            val ex2 = assertFailsWith<IllegalArgumentException> { nonPoly.concat(poly) }
+            assertTrue(ex2.message!!.contains("polymorphic flag"))
+        }
+    }
+
+    @Test
+    fun `mixed-flag intersectSavingOrder throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val ex1 = assertFailsWith<IllegalArgumentException> { poly.intersectSavingOrder(nonPoly) }
+            assertTrue(ex1.message!!.contains("polymorphic flag"))
+            val ex2 = assertFailsWith<IllegalArgumentException> { nonPoly.intersectSavingOrder(poly) }
+            assertTrue(ex2.message!!.contains("polymorphic flag"))
+        }
+    }
+
+    @Test
+    fun `same-flag polymorphic true combination succeeds with correct results`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly1 = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val poly2 = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = true)
+
+            val unioned = poly1.union(poly2) as YTDBEntityIterable
+            assertTrue(unioned.polymorphic)
+            assertNamesExactly(unioned, "base1", "user1", "guest1")
+
+            val intersected = poly1.intersect(poly2) as YTDBEntityIterable
+            assertTrue(intersected.polymorphic)
+            assertNamesExactly(intersected, "user1")
+
+            val minused = poly1.minus(poly2) as YTDBEntityIterable
+            assertTrue(minused.polymorphic)
+            assertNamesExactly(minused, "base1", "guest1")
+
+            val concatenated = poly1.concat(poly2) as YTDBEntityIterable
+            assertTrue(concatenated.polymorphic)
+            assertEquals(4, concatenated.count())
+        }
+    }
+
+    @Test
+    fun `EMPTY sentinel has polymorphic true by default`() {
+        assertTrue(YTDBEntityIterable.EMPTY.polymorphic)
+    }
+
+    @Test
+    fun `EMPTY as left operand preserves right operand flag`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val empty = YTDBEntityIterable.EMPTY
+
+            // EMPTY.union returns right directly — flag preserved
+            val unionResult = empty.union(nonPoly)
+            assertFalse((unionResult as YTDBEntityIterable).polymorphic)
+            assertNamesExactly(unionResult, "base1")
+
+            // EMPTY.concat returns right directly — flag preserved
+            val concatResult = empty.concat(nonPoly)
+            assertFalse((concatResult as YTDBEntityIterable).polymorphic)
+            assertNamesExactly(concatResult, "base1")
+
+            // EMPTY.intersect returns EMPTY itself
+            assertSame(empty.intersect(nonPoly), YTDBEntityIterable.EMPTY)
+
+            // EMPTY.minus returns EMPTY itself
+            assertSame(empty.minus(nonPoly), YTDBEntityIterable.EMPTY)
+
+            // EMPTY.intersectSavingOrder returns EMPTY itself
+            assertSame(empty.intersectSavingOrder(nonPoly), YTDBEntityIterable.EMPTY)
+        }
+    }
+
+    @Test
+    fun `chained combination preserves flag and validates correctly`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly1 = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPoly2 = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPoly3 = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            val combined = nonPoly1.union(nonPoly2).union(nonPoly3)
+            assertFalse((combined as YTDBEntityIterable).polymorphic)
+            assertNamesExactly(combined, "base1", "user1", "guest1")
+        }
+    }
+
+    @Test
+    fun `chained combination result rejects mismatched flag`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly1 = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val nonPoly2 = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val poly = YTDBEntityIterable.where(Guest.CLASS, tx, GremlinBlock.All, polymorphic = true)
+
+            val combined = nonPoly1.union(nonPoly2) // polymorphic=false
+            assertFailsWith<IllegalArgumentException> { combined.intersect(poly) }
+        }
+    }
+}

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryCombineMatrixTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryCombineMatrixTest.kt
@@ -24,6 +24,7 @@ import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock.Sort
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock.SortDirection
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
@@ -292,5 +293,81 @@ class GremlinQueryCombineMatrixTest {
         check(sliced, "d", cond,  "Aggregate")
         check(cond,   "i", sliced,"Aggregate")
         check(cond,   "d", sliced,"Aggregate")
+    }
+
+    // =========================================================================
+    // UnionAll × Labeled(Where) — O20b with label preservation
+    // =========================================================================
+
+    @Test
+    fun `UnionAll x Labeled(Where) — intersect distributes condition and preserves label`() {
+        // Build UnionAll directly — union() of same-label conditions fuses them,
+        // so we use unionAll() to get a real UnionAll node.
+        val unionQ = Order(cond.unionAll(cond2), GremlinBlock.Dedup)
+
+        // O17 strips Dedup, O20b fires on inner UnionAll: distributes the condition
+        // into branches and wraps with label (O20b-fix). O17 re-wraps with Dedup.
+        check(unionQ, "i", cond, "Dedup(Labeled(UnionAll))")
+        assertEquals("Issue", ((unionQ.intersect(cond) as Order).inner as Labeled).label)
+
+        // Symmetric: Labeled(Where) ∩ Order(UnionAll, Dedup).
+        check(cond, "i", unionQ, "Dedup(Labeled(UnionAll))")
+        assertEquals("Issue", ((cond.intersect(unionQ) as Order).inner as Labeled).label)
+    }
+
+    @Test
+    fun `UnionAll x Labeled(Where) — intersect with different label distributes and preserves label`() {
+        val unionQ = Order(cond.unionAll(cond2), GremlinBlock.Dedup)
+
+        // O20b distributes the condition into branches and wraps with the label.
+        // The label mismatch (Issue vs Project) is not detected at the UnionAll level
+        // because extractLabel(UnionAll) returns null. The resulting traversal
+        // applies hasLabel("Project") after the union, correctly producing an empty
+        // result (Issue entities don't match Project label).
+        check(unionQ, "i", condDiffLabel, "Dedup(Labeled(UnionAll))")
+        assertEquals("Project", ((unionQ.intersect(condDiffLabel) as Order).inner as Labeled).label)
+
+        check(condDiffLabel, "i", unionQ, "Dedup(Labeled(UnionAll))")
+        assertEquals("Project", ((condDiffLabel.intersect(unionQ) as Order).inner as Labeled).label)
+    }
+
+    @Test
+    fun `UnionAll x Labeled(Where) — intersect with Where(All) preserves label`() {
+        // This is the case that was broken before the O20b-fix: extractCondition
+        // returns All (identity in then()), so branches are unchanged. Without the
+        // fix, the label was lost and the intersect became a no-op.
+        val unionQ = Order(cond.unionAll(cond2), GremlinBlock.Dedup)
+        val allOfType = Labeled(GremlinQuery.Where.of(GremlinBlock.All), "Issue")
+
+        check(unionQ, "i", allOfType, "Dedup(Labeled(UnionAll))")
+        assertEquals("Issue", ((unionQ.intersect(allOfType) as Order).inner as Labeled).label)
+
+        check(allOfType, "i", unionQ, "Dedup(Labeled(UnionAll))")
+        assertEquals("Issue", ((allOfType.intersect(unionQ) as Order).inner as Labeled).label)
+    }
+
+    @Test
+    fun `UnionAll x ByIds — intersect distributes condition without label wrapping`() {
+        // ByIds is a bare Condition (no Labeled wrapper), so extractLabel returns null.
+        // O20b distributes IdWithin into each branch and wraps with Dedup (else branch).
+        val unionQ = Order(cond.unionAll(cond2), GremlinBlock.Dedup)
+
+        // O17 strips Dedup, O20b fires: extractLabel(byids) = null → else branch.
+        check(unionQ, "i", byids, "Dedup(UnionAll)")
+        check(byids, "i", unionQ, "Dedup(UnionAll)")
+    }
+
+    @Test
+    fun `bare UnionAll x Labeled(Where) — intersect preserves label without Dedup`() {
+        // Bare UnionAll (from concat, no Order(Dedup) wrapper) — no O17 involvement.
+        // O20b fires directly: extracts label, wraps with Labeled but no Dedup.
+        // This is correct for concat semantics (UNION ALL preserves duplicates).
+        val bareUnion = cond.unionAll(cond2)
+
+        check(bareUnion, "i", cond, "Labeled(UnionAll)")
+        assertEquals("Issue", (bareUnion.intersect(cond) as Labeled).label)
+
+        check(cond, "i", bareUnion, "Labeled(UnionAll)")
+        assertEquals("Issue", (cond.intersect(bareUnion) as Labeled).label)
     }
 }

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
@@ -43,7 +43,13 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
             _sortEngine = value.notNull.apply { queryEngine = this@QueryEngine }
         }
 
-    open fun queryGetAll(entityType: String): EntityIterable = query(null, entityType, NodeFactory.all())
+    open fun queryGetAll(entityType: String, polymorphic: Boolean = true): EntityIterable {
+        if (modelMetaData != null && modelMetaData.getEntityMetaData(entityType) == null) {
+            return YTDBEntityIterable.EMPTY
+        }
+        val txn = persistentStore.andCheckCurrentTransaction as YTDBStoreTransaction
+        return txn.getAll(entityType, polymorphic)
+    }
 
     open fun query(entityType: String, tree: NodeBase): EntityIterable = query(null, entityType, tree)
 
@@ -167,7 +173,7 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
         return if (it is EntityIterable) {
             it.selectManyDistinct(linkName)
         } else {
-            return it?.let { inMemorySelectManyDistinct(it, linkName) } ?: YTDBEntityIterable.EMPTY
+            it?.let { inMemorySelectManyDistinct(it, linkName) } ?: YTDBEntityIterable.EMPTY
         }
     }
 
@@ -224,7 +230,8 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
                     txn as YTDBStoreTransaction,
                     left.query.intersect(
                         GremlinQuery.ByIds(rightIds)
-                    )
+                    ),
+                    left.polymorphic
                 )
             } else {
                 ids = getAsEntityIdSet(left)
@@ -235,7 +242,8 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
             if (leftValues.size < 20) {
                 return YTDBEntityIterable.query(
                     txn as YTDBStoreTransaction,
-                    GremlinQuery.ByIds(leftValues).intersect(right.query)
+                    GremlinQuery.ByIds(leftValues).intersect(right.query),
+                    right.polymorphic
                 )
             } else {
                 ids = getAsEntityIdSet(left)

--- a/dnq-query/src/test/kotlin/jetbrains/exodus/query/QueryEnginePolymorphicTest.kt
+++ b/dnq-query/src/test/kotlin/jetbrains/exodus/query/QueryEnginePolymorphicTest.kt
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.exodus.query
+
+import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
+import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBEntityIterable
+import jetbrains.exodus.entitystore.youtrackdb.testutil.*
+import jetbrains.exodus.query.metadata.entity
+import jetbrains.exodus.query.metadata.oModel
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class QueryEnginePolymorphicTest : OTestMixin {
+
+    @Rule
+    @JvmField
+    val orientDbRule = InMemoryYouTrackDB()
+
+    override val youTrackDb = orientDbRule
+
+    private fun givenEngine(): QueryEngine {
+        // OUsersWithInheritanceTestCase sets up: BaseUser -> {User, Guest, Admin, Agent}
+        // with entities: u1, u2, ag1, ag2, ad1, ad2, g1
+        OUsersWithInheritanceTestCase(youTrackDb)
+
+        val model = oModel(youTrackDb.provider) {
+            entity(BaseUser.CLASS)
+            entity(User.CLASS, BaseUser.CLASS)
+            entity(Guest.CLASS, BaseUser.CLASS)
+            entity(Admin.CLASS, BaseUser.CLASS)
+            entity(Agent.CLASS, BaseUser.CLASS)
+        }.apply { prepare() }
+
+        return QueryEngine(model, youTrackDb.store).also {
+            it.sortEngine = SortEngine()
+        }
+    }
+
+    @Test
+    fun `non-polymorphic queryGetAll on base type excludes subtypes`() {
+        val engine = givenEngine()
+
+        withStoreTx {
+            // BaseUser has no direct instances — only subtypes exist
+            val result = engine.queryGetAll(BaseUser.CLASS, polymorphic = false)
+            assertEquals(0L, result.count())
+        }
+    }
+
+    @Test
+    fun `non-polymorphic queryGetAll on leaf type returns its instances`() {
+        val engine = givenEngine()
+
+        withStoreTx {
+            val result = engine.queryGetAll(User.CLASS, polymorphic = false)
+            assertNamesExactly(result, "u1", "u2")
+        }
+    }
+
+    @Test
+    fun `default queryGetAll returns all subtypes`() {
+        val engine = givenEngine()
+
+        withStoreTx {
+            val result = engine.queryGetAll(BaseUser.CLASS)
+            assertNamesExactly(result, "u1", "u2", "ag1", "ag2", "ad1", "ad2", "g1")
+        }
+    }
+
+    @Test
+    fun `queryGetAll for unknown entity type returns EMPTY`() {
+        val engine = givenEngine()
+
+        withStoreTx {
+            val result = engine.queryGetAll("NoSuchType", polymorphic = false)
+            assertTrue(result === YTDBEntityIterable.EMPTY)
+
+            val polyResult = engine.queryGetAll("NoSuchType")
+            assertTrue(polyResult === YTDBEntityIterable.EMPTY)
+        }
+    }
+
+    @Test
+    fun `inMemoryIntersect preserves polymorphic flag from left YTDBEntityIterable`() {
+        val engine = givenEngine()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(
+                User.CLASS, tx, GremlinBlock.All, polymorphic = false
+            )
+            // Create a small in-memory list (under 20 elements) to trigger
+            // the YTDBEntityIterable.query() path in inMemoryIntersect
+            val inMemory = nonPoly.toList()
+
+            val result = engine.inMemoryIntersect(nonPoly, inMemory)
+            assertTrue(result is YTDBEntityIterable)
+            assertFalse((result as YTDBEntityIterable).polymorphic)
+            assertNamesExactly(result, "u1", "u2")
+        }
+    }
+
+    @Test
+    fun `inMemoryIntersect preserves polymorphic flag from right YTDBEntityIterable`() {
+        val engine = givenEngine()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(
+                User.CLASS, tx, GremlinBlock.All, polymorphic = false
+            )
+            val inMemory = nonPoly.toList()
+
+            val result = engine.inMemoryIntersect(inMemory, nonPoly)
+            assertTrue(result is YTDBEntityIterable)
+            assertFalse((result as YTDBEntityIterable).polymorphic)
+            assertNamesExactly(result, "u1", "u2")
+        }
+    }
+
+    @Test
+    fun `inMemoryIntersect default polymorphic flag is true`() {
+        val engine = givenEngine()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All)
+            val inMemory = poly.toList()
+
+            val result = engine.inMemoryIntersect(poly, inMemory)
+            assertTrue(result is YTDBEntityIterable)
+            assertTrue((result as YTDBEntityIterable).polymorphic)
+            assertNamesExactly(result, "u1", "u2")
+        }
+    }
+}

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIterableWrapper.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIterableWrapper.kt
@@ -131,6 +131,9 @@ open class PersistentEntityIterableWrapper(
         get() = (unwrap() as? YTDBEntityIterable)?.query
             ?: throw IllegalStateException("EntityIterable is not a YTDBEntityIterable")
 
+    override val polymorphic: Boolean
+        get() = (unwrap() as? YTDBEntityIterable)?.polymorphic ?: true
+
     override fun traversal(): GraphTraversal<*, YTDBVertex> =
         (unwrap() as? YTDBEntityIterable)?.traversal()
             ?: throw IllegalStateException("EntityIterable is not a YTDBEntityIterable")

--- a/dnq/src/main/kotlin/kotlinx/dnq/XdEntityType.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/XdEntityType.kt
@@ -26,8 +26,8 @@ abstract class XdEntityType<out T : XdEntity>(val storeContainer: StoreContainer
     val entityStore: TransientEntityStore
         get() = storeContainer.store
 
-    fun all(): XdQuery<T> {
-        return XdQueryImpl(entityStore.queryEngine.queryGetAll(entityType), this)
+    fun all(polymorphic: Boolean = true): XdQuery<T> {
+        return XdQueryImpl(entityStore.queryEngine.queryGetAll(entityType, polymorphic), this)
     }
 
     open fun new(init: (T.() -> Unit) = {}): T {

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/XdQueryEngine.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/XdQueryEngine.kt
@@ -38,8 +38,8 @@ class XdQueryEngine(val store: TransientEntityStore) :
 
     private val session get() = store.threadSessionOrThrow
 
-    override fun queryGetAll(entityType: String): EntityIterable {
-        return wrap(super.queryGetAll(entityType))
+    override fun queryGetAll(entityType: String, polymorphic: Boolean): EntityIterable {
+        return wrap(super.queryGetAll(entityType, polymorphic))
     }
 
     override fun query(entityType: String, tree: NodeBase): EntityIterable {
@@ -88,10 +88,10 @@ class XdQueryEngine(val store: TransientEntityStore) :
     }
 
     fun wrap(it: Iterable<Entity>): EntityIterable {
-        if (it is EntityIterable){
-            return session.createPersistentEntityIterableWrapper(it)
+        return if (it is EntityIterable){
+            session.createPersistentEntityIterableWrapper(it)
         } else {
-            return session.createPersistentEntityIterableWrapper(InMemoryEntityIterable(it, session, this))
+            session.createPersistentEntityIterableWrapper(InMemoryEntityIterable(it, session, this))
         }
     }
 

--- a/dnq/src/test/kotlin/kotlinx/dnq/XdEntityTypePolymorphicTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/XdEntityTypePolymorphicTest.kt
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import com.google.common.truth.Truth.assertThat
+import com.jetbrains.teamsys.dnq.database.PersistentEntityIterableWrapper
+import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBEntityIterable
+import kotlinx.dnq.query.filter
+import kotlinx.dnq.query.sortedBy
+import kotlinx.dnq.query.toList
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class XdEntityTypePolymorphicTest : DBTest() {
+
+    @Test
+    fun `non-polymorphic all on leaf type with no subtypes behaves like polymorphic`() {
+        transactional {
+            User.new { login = "user1"; skill = 1 }
+            User.new { login = "user2"; skill = 2 }
+        }
+
+        transactional(readonly = true) {
+            val nonPoly = User.all(polymorphic = false).toList()
+            val poly = User.all(polymorphic = true).toList()
+            assertThat(nonPoly.map { it.login }).containsExactly("user1", "user2")
+            assertThat(nonPoly).containsExactlyElementsIn(poly)
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all on abstract base type returns empty`() {
+        transactional {
+            User.new { login = "user1"; skill = 1 }
+            User.new { login = "user2"; skill = 2 }
+        }
+
+        transactional(readonly = true) {
+            val result = BaseUser.all(polymorphic = false).toList()
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun `default polymorphic all on base type returns subtypes`() {
+        transactional {
+            User.new { login = "user1"; skill = 1 }
+            User.new { login = "user2"; skill = 2 }
+        }
+
+        transactional(readonly = true) {
+            val result = BaseUser.all().toList()
+            assertThat(result).hasSize(2)
+            assertThat(result.map { it.login }).containsExactly("user1", "user2")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all on concrete sibling returns only its instances`() {
+        transactional {
+            val user = User.new { login = "owner"; skill = 1 }
+            val root = RootGroup.new { name = "rootGroup" }
+            NestedGroup.new { name = "nestedGroup"; parentGroup = root; owner = user }
+        }
+
+        transactional(readonly = true) {
+            val nestedOnly = NestedGroup.all(polymorphic = false).toList()
+            assertThat(nestedOnly).hasSize(1)
+            assertThat(nestedOnly.map { it.name }).containsExactly("nestedGroup")
+
+            val rootOnly = RootGroup.all(polymorphic = false).toList()
+            assertThat(rootOnly).hasSize(1)
+            assertThat(rootOnly.map { it.name }).containsExactly("rootGroup")
+
+            val allGroups = Group.all().toList()
+            assertThat(allGroups).hasSize(2)
+            assertThat(allGroups.map { it.name }).containsExactly("rootGroup", "nestedGroup")
+
+            val nonPolyBase = Group.all(polymorphic = false).toList()
+            assertThat(nonPolyBase).isEmpty()
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all wraps result in PersistentEntityIterableWrapper with correct flag`() {
+        transactional {
+            User.new { login = "user1"; skill = 1 }
+        }
+
+        transactional(readonly = true) {
+            val nonPolyQuery = User.all(polymorphic = false)
+            val nonPolyIterable = nonPolyQuery.entityIterable
+            assertThat(nonPolyIterable).isInstanceOf(PersistentEntityIterableWrapper::class.java)
+            assertThat((nonPolyIterable as YTDBEntityIterable).polymorphic).isFalse()
+
+            val polyQuery = User.all()
+            val polyIterable = polyQuery.entityIterable
+            assertThat(polyIterable).isInstanceOf(PersistentEntityIterableWrapper::class.java)
+            assertThat((polyIterable as YTDBEntityIterable).polymorphic).isTrue()
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all chained with filter throws due to polymorphic mismatch`() {
+        // filter() internally intersects the non-polymorphic instance with a
+        // default-polymorphic tree result from QueryEngine.query(), triggering
+        // Track 2's combination validation. This is a known limitation:
+        // filtering non-polymorphic queries requires lower-level APIs
+        // (YTDBStoreTransaction.find* with polymorphic=false).
+        transactional {
+            User.new { login = "user1"; skill = 5 }
+        }
+
+        transactional(readonly = true) {
+            val exception = assertFailsWith<IllegalArgumentException> {
+                User.all(polymorphic = false).filter {
+                    it.skill gt 3
+                }.toList()
+            }
+            assertThat(exception.message).contains("non-polymorphic")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all chained with sortedBy returns only exact type`() {
+        transactional {
+            val user = User.new { login = "owner"; skill = 1 }
+            val root = RootGroup.new { name = "b_root" }
+            RootGroup.new { name = "a_root" }
+            NestedGroup.new { name = "c_nested"; parentGroup = root; owner = user }
+        }
+
+        transactional(readonly = true) {
+            // Non-polymorphic sortedBy on abstract base returns empty —
+            // would return 3 groups sorted if the flag were ignored
+            val nonPolySorted = Group.all(polymorphic = false).sortedBy(Group::name).toList()
+            assertThat(nonPolySorted).isEmpty()
+
+            // Contrast: polymorphic sortedBy returns all subtypes in order
+            val allGroupsSorted = Group.all().sortedBy(Group::name).toList()
+            assertThat(allGroupsSorted.map { it.name })
+                .containsExactly("a_root", "b_root", "c_nested").inOrder()
+
+            // Known limitation: SortEngine.sort() creates a new iterable via
+            // txn.sort() which defaults to polymorphic=true. The non-polymorphic
+            // flag from the source is not propagated through the sort path.
+            val sortedIterable = Group.all(polymorphic = false).sortedBy(Group::name).entityIterable
+            assertThat((sortedIterable as YTDBEntityIterable).polymorphic).isTrue()
+        }
+    }
+}

--- a/docs/adr/polymorphic-queries/adr.md
+++ b/docs/adr/polymorphic-queries/adr.md
@@ -1,0 +1,311 @@
+# Non-Polymorphic Query Support — Architecture Decision Record
+
+## Summary
+
+YouTrackDB's `hasLabel` traversal step matches a type and all its subclasses
+by default (polymorphic semantics). This feature adds a `polymorphic: Boolean`
+flag (default `true`) that lets callers opt into non-polymorphic queries where
+`getAll("Parent")` returns only exact `Parent` instances. The flag is carried
+on `YTDBEntityIterableImpl`, always set explicitly on the
+`YTDBGraphTraversalSource`, validated at combination time, and exposed at
+three API layers: entity iterable, store transaction, and DNQ entity type.
+Two engine-level issues affecting non-polymorphic `union()`/`concat()`
+operations were fixed: anonymous child traversal strategy propagation in
+`GremlinQuery.UnionAll`, and `hasLabel` filter preservation in the O20b
+optimizer path.
+
+## Goals
+
+- **Allow exact-type queries:** `getAll("Parent")` can return only exact
+  `Parent` instances (not subclasses) when `polymorphic = false`.
+  *Achieved as planned.*
+
+- **Expose through three API layers:** `YTDBEntityIterable`,
+  `YTDBStoreTransaction`, and `XdEntityType`.
+  *Achieved as planned.*
+
+- **Fail-fast on mixed-flag combinations:** Reject at combination time any
+  attempt to merge a polymorphic iterable with a non-polymorphic one.
+  *Achieved as planned.* The validation also catches unintended mixing
+  through DNQ query extensions (e.g., `filter()` on a non-polymorphic query).
+
+## Constraints
+
+- **Binary flag on the traversal source.** YouTrackDB's
+  `YTDBGraphTraversalSource.with(YTDBQueryConfigParam.polymorphicQuery, Boolean)`
+  controls the entire traversal — no per-step granularity.
+  *Confirmed during implementation.*
+
+- **Default must remain `true`.** All existing callers are polymorphic;
+  the flag is opt-in for non-polymorphic behavior.
+  *Maintained — all existing tests pass without modification.*
+
+- **In-memory paths are unaffected.** `InMemoryEntityIterable` and
+  `TransientEntityIterable` operate on materialized entity-ID sets, not
+  Gremlin traversals.
+  *Confirmed.*
+
+- **`EMPTY` sentinel is neutral.** Combination methods short-circuit on
+  `EMPTY` before reaching the flag check.
+  *Confirmed. `EMPTY.polymorphic` returns `true` (the interface default)
+  but the value is never compared because short-circuits execute first.*
+
+- **New constraint discovered: explicit config always required.** YouTrackDB
+  resolves `polymorphicQuery` via a two-level fallback: explicit traversal
+  config → `GlobalConfiguration.QUERY_GREMLIN_POLYMORPHIC_BY_DEFAULT`.
+  To avoid breakage if the global default changes, the flag is always set
+  explicitly via `.with()` regardless of value.
+
+- **New constraint discovered: anonymous traversal OptionsStrategy propagation.**
+  TinkerPop's anonymous child traversals (used by `union()` steps) do not
+  inherit the parent traversal's `OptionsStrategy`. `YTDBGraphStepStrategy`
+  requires it to read `polymorphicQuery`, so `OptionsStrategy` must be
+  explicitly added to each child traversal in `UnionAll.subtraversals()`.
+  The graph reference is propagated automatically by TinkerPop.
+
+## Architecture Notes
+
+### Component Map
+
+```mermaid
+flowchart LR
+    subgraph DNQ ["DNQ layer"]
+        XdET["XdEntityType\n.all(polymorphic)"]
+    end
+    subgraph QE ["Query Engine"]
+        XdQEng["XdQueryEngine\n.queryGetAll(entityType, polymorphic)"]
+        QEng["QueryEngine\n.queryGetAll(entityType, polymorphic)"]
+        QEng2["QueryEngine\n.inMemoryIntersect()"]
+    end
+    subgraph TX ["Store Transaction"]
+        Tx["YTDBStoreTransaction\n.getAll / .find* (polymorphic)"]
+        TxImpl["YTDBStoreTransactionImpl"]
+    end
+    subgraph EI ["Entity Iterable"]
+        PEW["PersistentEntityIterableWrapper\ndelegates polymorphic"]
+        YEI["YTDBEntityIterable\n.where() / .query()"]
+        YEII["YTDBEntityIterableImpl\ncarries polymorphic flag"]
+        PEW --> YEII
+    end
+    subgraph GQL ["Gremlin Query Model"]
+        UA["GremlinQuery.UnionAll\npropagates OptionsStrategy\nto child traversals"]
+        OPT["GremlinQueryOptimizer\nO20b label preservation"]
+    end
+    subgraph YTDB ["YouTrackDB"]
+        GTS["YTDBGraphTraversalSource\n.with(polymorphicQuery, bool)"]
+    end
+
+    XdET --> XdQEng
+    XdQEng --> QEng
+    QEng --> Tx
+    Tx --> TxImpl
+    TxImpl --> YEI
+    YEI --> YEII
+    QEng2 --> YEI
+    YEII -->|"traversal()"| GTS
+    YEII -->|"query tree"| UA
+    UA -->|"child traversals"| GTS
+    OPT -.->|"optimizes"| UA
+```
+
+- **YTDBEntityIterableImpl** — carries the `polymorphic` flag as a constructor
+  parameter. Applies it in `traversal()` via `.with(polymorphicQuery, polymorphic)`.
+  Validates flag consistency in combination methods via `requirePolymorphicMatch()`.
+  Propagates through `modify()`, `selectMany()`, and `findLinks()` (from
+  `entities` parameter).
+- **YTDBEntityIterable companion** — `where()` and `query()` factory methods
+  accept `polymorphic: Boolean = true` (with `@JvmOverloads`).
+- **PersistentEntityIterableWrapper** — delegates `polymorphic` to
+  `unwrap()` with safe default `true`.
+- **YTDBStoreTransaction / Impl** — 20+ query methods gain `polymorphic`
+  parameter via two-method pattern (for Java-interface overrides) or Kotlin
+  default parameters (for non-override methods).
+- **QueryEngine** — single `queryGetAll(entityType, polymorphic = true)`.
+  `inMemoryIntersect()` propagates the flag from the `YTDBEntityIterable`
+  operand in the under-20 optimization path.
+- **XdQueryEngine** — overrides `queryGetAll(entityType, polymorphic)` and
+  wraps the result. Virtual dispatch ensures all paths go through `wrap()`.
+- **XdEntityType.all(polymorphic)** — public DNQ entry point.
+- **GremlinQuery.UnionAll** — `subtraversals()` adds the parent's
+  `OptionsStrategy` to each anonymous child traversal, compensating for
+  TinkerPop's lack of `OptionsStrategy` propagation to anonymous traversals
+  inside `union()`. Only `OptionsStrategy` is propagated — the graph
+  reference is inherited automatically.
+- **GremlinQueryOptimizer** — O20b path re-applies `Labeled.of()` after
+  distributing an intersect condition into `UnionAll` branches, preventing
+  `hasLabel` filter loss.
+
+### Decision Records
+
+#### D1: Flag lives on YTDBEntityIterableImpl, not on GremlinQuery
+- **Alternatives considered:** (A) Store on `GremlinQuery` nodes.
+  (B) Store on `YTDBEntityIterableImpl`.
+- **Decision:** Option B — the flag is a traversal execution concern, not a
+  query-algebra concern.
+- **Outcome:** Implemented as planned. The flag survives the
+  `PersistentEntityIterableWrapper` wrapping layer via delegation.
+  `findLinks()` correctly propagates from the `entities` parameter because
+  the traversal starts from its query.
+
+#### D2: Fail-fast on polymorphic/non-polymorphic combination
+- **Alternatives considered:** (A) Silently coerce. (B) Throw error.
+  (C) Split into two traversals.
+- **Decision:** Option B — explicit, safe, caller-visible.
+- **Outcome:** Implemented as planned via `requirePolymorphicMatch()`.
+  The validation also caught an unintended interaction: `filter()` on a
+  non-polymorphic query triggers the check because `QueryEngine.query()`
+  internally intersects with a default-polymorphic filter predicate.
+  This fail-fast behavior is correct — it prevents silently wrong results.
+
+#### D3: Default parameter values preserve backward compatibility
+- **Alternatives considered:** (A) New method overloads.
+  (B) Default parameter `polymorphic: Boolean = true`.
+- **Decision:** Option B for Kotlin-native contexts. For Java-interface
+  overrides in `YTDBStoreTransaction`, a two-method pattern was used
+  (existing override gets default body delegating to new method with
+  explicit parameter) because Java interface overrides cannot have
+  Kotlin default parameters.
+- **Outcome:** All existing call sites continue to work unchanged. The
+  two-method pattern was not anticipated during planning but is a standard
+  Kotlin-Java interop approach.
+
+#### D4: Always set traversal config explicitly (emerged during implementation)
+- **Context:** Discovered during Track 1 that YouTrackDB resolves
+  `polymorphicQuery` via a two-level fallback: explicit traversal config →
+  `GlobalConfiguration.QUERY_GREMLIN_POLYMORPHIC_BY_DEFAULT`.
+- **Decision:** Always call `gs.with(YTDBQueryConfigParam.polymorphicQuery, polymorphic)`
+  in `traversal()`, even when `polymorphic = true`. This overrides the
+  global config explicitly in both directions.
+- **Rationale:** Avoids silent breakage if the global default is ever changed
+  or if test configurations set it differently. The cost is one additional
+  `.with()` call per traversal, which is negligible.
+
+#### D5: Propagate OptionsStrategy to anonymous child traversals (emerged during Track 5)
+- **Context:** `GremlinQuery.UnionAll.subtraversals()` originally created
+  anonymous child traversals via `__.start()` without the parent's
+  `OptionsStrategy`. `YTDBGraphStepStrategy` requires it to read
+  `polymorphicQuery`.
+- **Decision:** `subtraversals()` extracts the `OptionsStrategy` from the
+  parent's strategies and adds it to each anonymous child via
+  `admin.strategies.addStrategies()`. Only `OptionsStrategy` is propagated —
+  the full strategy list and graph reference are inherited automatically by
+  TinkerPop when the child is integrated into the parent via `union()`.
+- **Rationale:** `GraphTraversal.with()` cannot be used — it is a step
+  modulator, not traversal-wide config. Propagating only `OptionsStrategy`
+  (rather than all strategies) avoids interfering with TinkerPop's own
+  strategy application on child traversals.
+
+#### D6: O20b label preservation after condition distribution (emerged during Track 5)
+- **Context:** The Gremlin query optimizer's O20b path distributes an
+  intersect condition into `UnionAll` branches. `extractCondition()` strips
+  the `Labeled` wrapper, losing the `hasLabel` filter. TinkerPop's
+  `InlineFilterStrategy` merges consecutive `HasStep` objects, and
+  `YTDBHasLabelStep` evaluates multiple predicates with `anyMatch` (OR
+  semantics).
+- **Decision:** After distributing the condition into branches, re-apply
+  the label via `Labeled.of()`. The `hasLabel` step is placed after the
+  union at a different traversal level so `InlineFilterStrategy` cannot
+  merge it with branch-level `hasLabel` steps.
+- **Rationale:** Placing the label at a different traversal level (on the
+  union result, not on each branch) avoids the OR-merge behavior while
+  correctly filtering the combined result.
+
+### Invariants
+
+- A `YTDBEntityIterableImpl` with `polymorphic = false` produces a traversal
+  with `YTDBQueryConfigParam.polymorphicQuery = false` on the source.
+- A `YTDBEntityIterableImpl` with `polymorphic = true` produces a traversal
+  with `YTDBQueryConfigParam.polymorphicQuery = true` (explicitly set, not
+  relying on default).
+- Combining two `YTDBEntityIterableImpl` with different `polymorphic` values
+  via `intersect`/`union`/`minus`/`concat` throws `IllegalArgumentException`.
+- `YTDBEntityIterable.EMPTY` is compatible with either flag value (combination
+  methods short-circuit before the flag check).
+- Single-operand transforms propagate `this.polymorphic`; `findLinks()`
+  propagates `entities.polymorphic`.
+- All existing tests pass without modification.
+
+### Non-Goals
+
+- Per-step polymorphism within a single Gremlin traversal (YouTrackDB doesn't
+  support this).
+- Automatic splitting of mixed-polymorphic queries into separate traversals.
+- Fixing YouTrackDB engine-level `hasLabel` merging behavior (guarded at the
+  optimizer level instead).
+
+## Key Discoveries
+
+1. **YouTrackDB's two-level config fallback.** The engine resolves
+   `polymorphicQuery` via explicit traversal config →
+   `GlobalConfiguration.QUERY_GREMLIN_POLYMORPHIC_BY_DEFAULT` (set to `true`
+   in `YTDBDatabaseParams`). Relying on the global default is fragile — the
+   implementation always sets the flag explicitly. (Track 1, Step 1)
+
+2. **Gremlin query optimizer merges HasLabel conditions.** Combining
+   non-polymorphic queries via `union()`/`concat()` on types with an
+   inheritance relationship produces incorrect results. The optimizer merges
+   `HasLabel("BaseUser") OR HasLabel("User")` into a combined condition that
+   doesn't correctly interact with `polymorphicQuery = false`. This is a
+   YouTrackDB engine limitation, documented but not addressed (consistent
+   with the non-goals). (Track 1, Step 4)
+
+3. **Java-interface override limitation requires two-method pattern.** Kotlin
+   default parameters cannot be used on methods that override Java interface
+   methods. The `YTDBStoreTransaction` API uses a two-method pattern: the
+   existing override gets a default body delegating to a new overloaded
+   method with the explicit `polymorphic` parameter. Non-override methods
+   use Kotlin default parameters directly. (Track 3, Step 1)
+
+4. **`filter()` on non-polymorphic queries throws.** `QueryEngine.query()`
+   internally intersects the non-polymorphic iterable with a
+   default-polymorphic filter predicate iterable. The combination validation
+   catches this mismatch and throws `IllegalArgumentException`. Users
+   requiring filtered non-polymorphic results should use
+   `YTDBStoreTransaction.find*()` methods directly. (Track 4, Step 2)
+
+5. **`sortedBy()` flag reverts to `true`.** `SortEngine.sort()` creates a
+   new iterable via `txn.sort()` which defaults to `polymorphic = true`.
+   The sorted result content is correct (only exact-type instances), but
+   the flag reverts. Neither limitation affects the primary use case.
+   (Track 4, Step 2)
+
+6. **`findLinks()` propagates from `entities`, not `this`.** The result's
+   query tree is built from `entities.query`, not `this.query`, so the
+   polymorphic flag must come from the `entities` parameter. This was
+   specified in the plan and confirmed during implementation. (Track 1,
+   Step 2)
+
+7. **`Comparable<Nothing>` to `Comparable<*>` type widening.** New
+   overloaded `find` methods use `Comparable<*>` instead of
+   `Comparable<Nothing>` because they are no longer direct Java interface
+   overrides. This is a cosmetic alignment with Java raw types, not a
+   behavioral change. (Track 3, Step 1)
+
+8. **Anonymous traversals lose parent OptionsStrategy.** TinkerPop's
+   anonymous child traversals (created via `__.start()`) do not inherit
+   the parent's `OptionsStrategy`. `YTDBGraphStepStrategy` requires it
+   to read `polymorphicQuery`. This caused `union()`/`concat()` on
+   non-polymorphic queries with inherited types to return polymorphic
+   results. Fixed by adding the parent's `OptionsStrategy` to each child
+   traversal in `UnionAll.subtraversals()`. The graph reference is
+   propagated automatically by TinkerPop. `GraphTraversal.with()` cannot
+   be used — it is a step modulator, not traversal-wide config.
+   (Track 5, Step 1)
+
+9. **O20b optimizer loses Labeled wrapper during condition distribution.**
+   When the optimizer distributes an intersect condition into `UnionAll`
+   branches, `extractCondition()` strips the `Labeled` wrapper, losing the
+   `hasLabel` filter. This caused `union().intersect(type)` to silently
+   skip the type filter when the extracted condition was `All`. Fixed by
+   re-applying `Labeled.of()` after distribution — the `hasLabel` step is
+   placed after the union at a different traversal level. Pre-existing bug,
+   not caused by the polymorphic flag feature. (Track 5, Step 2)
+
+10. **TinkerPop HasLabel step merging with OR semantics.** `InlineFilterStrategy`
+    merges consecutive `HasStep` objects; `YTDBHasLabelStep` evaluates
+    multiple predicates with `anyMatch` (OR semantics), so
+    `hasLabel("Child").hasLabel("Parent")` matches anything that is either
+    `Child` or `Parent`. The optimizer guards against this at three points:
+    the O7 double-label guard (falls to Aggregate), the O20b label placement
+    (different traversal level), and the O19 `extractCondition` guard.
+    (Track 5, Step 2)

--- a/docs/adr/polymorphic-queries/design-final.md
+++ b/docs/adr/polymorphic-queries/design-final.md
@@ -1,0 +1,263 @@
+# Non-Polymorphic Query Support — Final Design
+
+## Overview
+
+This feature adds a `polymorphic: Boolean` flag to the query execution path
+so that `hasLabel("Type")` can optionally match only the exact type
+(non-polymorphic) instead of the type and all its subclasses (polymorphic,
+the default). The flag is carried on `YTDBEntityIterableImpl`, explicitly
+applied to the `YTDBGraphTraversalSource` at traversal-build time
+(always, for both `true` and `false`), validated when two iterables are
+combined, and surfaced through three API layers: entity iterable factories,
+store transaction methods, and DNQ entity types.
+
+**Deviations from original design:**
+- The traversal source is **always** configured via
+  `.with(polymorphicQuery, polymorphic)` regardless of flag value, not just
+  when `false`. This was discovered during implementation — YouTrackDB uses a
+  two-level fallback (explicit config → global default), and relying on the
+  global default is fragile.
+- `YTDBStoreTransaction` methods use a **two-method pattern** (override
+  with default body delegating to a new overloaded method) instead of plain
+  Kotlin default parameters, because Java-interface overrides cannot have
+  default parameters.
+- `QueryEngine.queryGetAll` is a single method with a default parameter
+  (the two-method pattern was only needed for Java-interface overrides in
+  `YTDBStoreTransaction`).
+
+## Class Design
+
+```mermaid
+classDiagram
+    class YTDBEntityIterable {
+        <<interface>>
+        +query: GremlinQuery
+        +polymorphic: Boolean  = true
+        +traversal(): GraphTraversal
+        +selectMany(linkName): EntityIterable
+        +where(entityType, tx, condition, polymorphic)$ YTDBEntityIterable
+        +query(tx, query, polymorphic)$ YTDBEntityIterable
+    }
+
+    class YTDBEntityIterableImpl {
+        -tx: YTDBStoreTransaction
+        +query: GremlinQuery
+        +polymorphic: Boolean  = true
+        +traversal(): GraphTraversal
+        +intersect(right): EntityIterable
+        +union(right): EntityIterable
+        +minus(right): EntityIterable
+        +concat(right): EntityIterable
+        +selectMany(linkName): EntityIterable
+        +findLinks(entities, linkName): EntityIterable
+        -modify(block): YTDBEntityIterableImpl
+        -requirePolymorphicMatch(right)
+    }
+
+    class PersistentEntityIterableWrapper {
+        #wrappedIterable: EntityIterable
+        +polymorphic: Boolean
+        +query: GremlinQuery
+        +traversal(): GraphTraversal
+    }
+
+    class YTDBStoreTransaction {
+        <<interface>>
+        +getAll(entityType): YTDBEntityIterable
+        +getAll(entityType, polymorphic): YTDBEntityIterable
+        +find(entityType, prop, value, polymorphic): YTDBEntityIterable
+        +findContaining(..., polymorphic): YTDBEntityIterable
+        +findLinks(..., polymorphic): YTDBEntityIterable
+        +sort(..., polymorphic): YTDBEntityIterable
+    }
+
+    class QueryEngine {
+        +queryGetAll(entityType, polymorphic): EntityIterable
+        +inMemoryIntersect(left, right): Iterable
+    }
+
+    class XdQueryEngine {
+        +queryGetAll(entityType, polymorphic): EntityIterable
+    }
+
+    class XdEntityType~T~ {
+        +all(polymorphic): XdQuery~T~
+    }
+
+    YTDBEntityIterable <|.. YTDBEntityIterableImpl
+    YTDBEntityIterable <|.. PersistentEntityIterableWrapper
+    PersistentEntityIterableWrapper o-- YTDBEntityIterableImpl : delegates via unwrap()
+    YTDBStoreTransaction <|.. YTDBStoreTransactionImpl
+    YTDBStoreTransactionImpl ..> YTDBEntityIterable : creates via where()/query()
+    QueryEngine <|-- XdQueryEngine
+    QueryEngine ..> YTDBStoreTransaction : delegates getAll()
+    XdEntityType ..> XdQueryEngine : queryGetAll()
+```
+
+**YTDBEntityIterable** defines `polymorphic: Boolean` with a default getter
+returning `true`. The `EMPTY` sentinel inherits this default. The companion
+factory methods `where()` and `query()` accept `polymorphic: Boolean = true`
+(with `@JvmOverloads`) and pass it to the `YTDBEntityIterableImpl` constructor.
+
+**YTDBEntityIterableImpl** stores `polymorphic` as a constructor parameter.
+`traversal()` always calls `gs.with(YTDBQueryConfigParam.polymorphicQuery, polymorphic)`
+to explicitly configure the traversal source. All methods that create new
+instances propagate the flag: `modify()` (used by `skip`, `take`, `distinct`,
+`reverse`), `selectMany()`, and combination methods (`intersect`, `union`,
+`minus`, `concat`). `findLinks(entities, linkName)` propagates from the
+`entities` parameter (not `this`) because the result's query tree is built
+from `entities.query`.
+
+**PersistentEntityIterableWrapper** delegates `polymorphic` to the unwrapped
+inner iterable: `(unwrap() as? YTDBEntityIterable)?.polymorphic ?: true`.
+The safe default of `true` matches the interface default for non-YTDB iterables.
+
+**YTDBStoreTransaction** adds `polymorphic: Boolean` to 20+ query methods
+using a two-method pattern: the existing Java-interface override gets a
+default body delegating to a new overloaded method with the explicit
+`polymorphic` parameter. Non-override methods use Kotlin default parameters
+directly.
+
+**QueryEngine** has a single `queryGetAll(entityType, polymorphic = true)`
+method. `inMemoryIntersect()` propagates the flag from the `YTDBEntityIterable`
+operand in the under-20 optimization path.
+
+**XdQueryEngine** overrides `queryGetAll(entityType, polymorphic)` and wraps
+the result via `wrap()`. The base `QueryEngine`'s single-arg call delegates
+to the two-arg version, so virtual dispatch routes all paths through wrapping.
+
+**XdEntityType.all(polymorphic)** is the public DNQ entry point.
+
+## Workflow
+
+### Query creation and traversal execution
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant XdET as XdEntityType
+    participant XdQE as XdQueryEngine
+    participant QE as QueryEngine
+    participant TxImpl as YTDBStoreTransactionImpl
+    participant EI as YTDBEntityIterable
+    participant Impl as YTDBEntityIterableImpl
+    participant GTS as YTDBGraphTraversalSource
+
+    Caller->>XdET: all(polymorphic=false)
+    XdET->>XdQE: queryGetAll(entityType, false)
+    XdQE->>QE: super.queryGetAll(entityType, false)
+    QE->>TxImpl: getAll(entityType, false)
+    TxImpl->>EI: where(entityType, tx, All, false)
+    EI->>Impl: new(tx, query, polymorphic=false)
+    XdQE->>XdQE: wrap(result)
+
+    Note over Caller,Impl: Later, when iterating...
+
+    Caller->>Impl: iterator() → traversal()
+    Impl->>GTS: g().with(polymorphicQuery, false)
+    GTS-->>Impl: configured source
+    Impl->>Impl: query.start(source)
+    Impl-->>Caller: GraphTraversal (non-polymorphic)
+```
+
+The flag is set at construction time and applied at traversal time. When
+`polymorphic` is `true`, `.with(polymorphicQuery, true)` is still called —
+this explicitly overrides the global configuration rather than relying on the
+engine's two-level fallback default.
+
+### Combination validation flow
+
+```mermaid
+flowchart TD
+    A["intersect / union / minus / concat"]
+    B{"right === EMPTY?"}
+    C["right.asYTDBIterable()"]
+    D["requirePolymorphicMatch(right)"]
+    E{"this.polymorphic == right.polymorphic?"}
+    F["Build combined query"]
+    G["new YTDBEntityIterableImpl(tx, combined, polymorphic)"]
+    ERR["throw IllegalArgumentException"]
+
+    A --> B
+    B -->|yes| SHORT["short-circuit (EMPTY/this)"]
+    B -->|no| C
+    C --> D
+    D --> E
+    E -->|yes| F
+    F --> G
+    E -->|no| ERR
+```
+
+All four combination methods follow the same pattern. The `EMPTY`
+short-circuit executes before the flag check — `EMPTY` is always compatible.
+`intersectSavingOrder` delegates to `intersect()` and inherits the check.
+
+### Flag propagation through single-operand transforms
+
+```mermaid
+flowchart LR
+    subgraph "Propagates this.polymorphic"
+        M["modify(block)"] --> N1["skip / take / distinct / reverse"]
+        SM["selectMany(linkName)"]
+    end
+    subgraph "Propagates entities.polymorphic"
+        FL["findLinks(entities, linkName)"]
+    end
+```
+
+`modify()` is a private helper that creates a new `YTDBEntityIterableImpl`
+with `this.polymorphic`. It is used by `skip()`, `take()`, `distinct()`,
+and the reverse path. `selectMany()` creates a `FollowLink` query and
+passes `this.polymorphic`. `findLinks()` is the exception: the result's
+query tree starts from `entities.query`, so it propagates
+`entities.asYTDBIterable().polymorphic`.
+
+## Known limitations at the DNQ level
+
+Two limitations exist when combining non-polymorphic queries with DNQ
+query extensions:
+
+1. **`filter()` throws `IllegalArgumentException`** — `QueryEngine.query()`
+   internally intersects the non-polymorphic iterable instance with a
+   default-polymorphic filter predicate iterable. Track 2's combination
+   validation catches the flag mismatch and rejects it. Users requiring
+   filtered non-polymorphic results should use `YTDBStoreTransaction.find*()`
+   methods with `polymorphic = false` directly.
+
+2. **`sortedBy()` flag reverts to `true`** — `SortEngine.sort()` creates a
+   new iterable via `txn.sort()` which defaults to `polymorphic = true`. The
+   sorted result content is correct (only exact-type instances appear), but
+   the flag on the resulting iterable is `true`. This means a subsequent
+   combination with a non-polymorphic iterable would not throw, even though
+   semantically the results came from a non-polymorphic query.
+
+Neither limitation affects the primary use case: `all(polymorphic = false)`
+for exact-type queries, with further filtering done at the transaction level.
+
+## Gremlin query optimizer interaction
+
+Two engine-level issues affect non-polymorphic queries in combination
+operations. Both are fully mitigated at the xodus-dnq layer.
+
+**Strategy propagation in UnionAll (fixed in Track 5).**
+The YouTrackDB engine does not propagate `polymorphicQuery` config from the
+traversal source to anonymous child traversals inside `union()` steps. This
+caused `union()`/`concat()` on non-polymorphic queries with inherited types
+to return polymorphic results. Track 5 fixes this in
+`GremlinQuery.UnionAll.subtraversals()` by adding the parent's
+`OptionsStrategy` onto each anonymous child traversal. Only `OptionsStrategy`
+is propagated — not the full strategy list — to avoid interfering with
+TinkerPop's own strategy application. The graph reference is not needed:
+TinkerPop propagates it automatically when the child is integrated into the
+parent via `union()`.
+
+**HasLabel step merging (guarded by optimizer).**
+TinkerPop's `InlineFilterStrategy` merges consecutive `HasStep` objects;
+`YTDBHasLabelStep` evaluates multiple predicates with `anyMatch` (OR
+semantics), allowing sibling types to pass incorrectly. This is prevented at
+three points: the O7 double-label guard falls to `Aggregate` when consecutive
+`hasLabel` steps would be produced; the O20b label placement (Track 5) puts
+`hasLabel` after the union at a different traversal level so
+`InlineFilterStrategy` cannot merge it with branch-level steps; and the O19
+`extractCondition` guard avoids producing double-labeled `FollowLink`
+queries.


### PR DESCRIPTION
## Summary

- Add a `polymorphic: Boolean` flag (default `true`) to the query execution path so that `getAll("Parent")` can return only exact `Parent` instances, not subclasses
- Expose the flag at three API layers: `YTDBEntityIterable`, `YTDBStoreTransaction` (20+ methods), and `XdEntityType.all()`
- Validate flag consistency at combination time — mixing polymorphic and non-polymorphic iterables in `intersect`/`union`/`minus`/`concat` throws `IllegalArgumentException`
- Fix `GremlinQuery.UnionAll` strategy propagation so `polymorphicQuery` config reaches anonymous child traversals inside `union()` steps
- Fix O20b optimizer label preservation when distributing intersect conditions into `UnionAll` branches

## Design

The flag lives on `YTDBEntityIterableImpl` (not `GremlinQuery`) and is always set explicitly on the `GraphTraversalSource` via `.with(polymorphicQuery, ...)` — never relying on the engine's global default. `PersistentEntityIterableWrapper` delegates the flag via `unwrap()`. `QueryEngine.inMemoryIntersect()` propagates the flag in the under-20 optimization path.

Known DNQ-level limitations: `filter()` throws on non-polymorphic queries (internal polymorphic intersection caught by validation); `sortedBy()` content is correct but flag reverts to `true`.

See `docs/adr/polymorphic-queries/design-final.md` and `adr.md` for full design and decision records.

## Test plan

- [x] 10 integration tests for core flag behavior (exact-type results, flag survival through chaining, combination propagation, findLinks, EMPTY)
- [x] 11 tests for combination validation (mixed-flag throws, same-flag success, EMPTY compatibility, chained validation)
- [x] 19 tests for `YTDBStoreTransaction` polymorphic methods (all where/query-based methods, sort, sortLinks)
- [x] 7 tests for `QueryEngine` (queryGetAll, inMemoryIntersect flag propagation)
- [x] 7 tests for DNQ-level `XdEntityType.all()` (hierarchy discrimination, wrapper delegation, filter/sortedBy limitations)
- [x] 13 tests for UnionAll strategy propagation and O20b optimizer fix (union/concat of inherited types, optimizer matrix)
- [x] All existing tests pass without modification