### PR TITLE
Fix publishing.gradle sourceJar artifact configuration for Gradle 8

### DIFF
--- a/publishing.gradle
+++ b/publishing.gradle
@@ -106,8 +106,8 @@ if (project.hasProperty("publishTo")) {
                 mavenJava(MavenPublication) {
                     from components.java
 
-                    artifact sourceJar {
-                        classifier 'sources'
+                    artifact(sourceJar) {
+                        classifier = 'sources'
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fixes TeamCity build failure: `Could not find method classifier() for arguments [sources] on task ':dnq:sourceJar' of type org.gradle.api.tasks.bundling.Jar`
- Root cause: `artifact sourceJar { classifier 'sources' }` was parsed by Groovy as `artifact(sourceJar { ... })`, so the closure was delegated to the `Jar` task (where `classifier()` was removed in Gradle 8), not to `MavenArtifact`
- Fix: add parentheses and use assignment — `artifact(sourceJar) { classifier = 'sources' }` — matching the style already used in the `ossrhUser`/`ossrhPassword` branch (line 21–23)

## Test plan
- [x] `./gradlew -PpublishTo=file:///tmp/test-repo :dnq:sourceJar` succeeds
- [x] `./gradlew -PpublishTo=file:///tmp/test-repo :dnq:publishMavenJavaPublicationToMavenRepository` produces `dnq-3.0.dev-sources.jar` with correct classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)