### PR TITLE
XD-1265 Add transactional(isNew=true) for independent nested transactions

### DIFF
--- a/dnq-entity-store/build.gradle.kts
+++ b/dnq-entity-store/build.gradle.kts
@@ -1,4 +1,4 @@
-val ytdbVersion = "0.5.0-20260415.232807-4633c0b-SNAPSHOT"
+val ytdbVersion = "0.5.0-20260416.230349-d5bf7fd-SNAPSHOT"
 
 val ktorVersion = "3.1.3"
 val graalVmVersion = "22.0.0.2"

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseCompacter.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseCompacter.kt
@@ -15,30 +15,37 @@
  */
 package jetbrains.exodus.entitystore.youtrackdb
 
-import com.jetbrains.youtrackdb.api.YouTrackDB
 import com.jetbrains.youtrackdb.internal.core.command.CommandOutputListener
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl
 import com.jetbrains.youtrackdb.internal.core.db.tool.DatabaseExport
 import com.jetbrains.youtrackdb.internal.core.db.tool.DatabaseImport
 import mu.KLogging
 import java.io.File
 
 class YTDBDatabaseCompacter(
-    private val db: YouTrackDB,
-    private val dbProvider: YTDBDatabaseProviderImpl,
+    private val database: YouTrackDBImpl,
     private val params: YTDBDatabaseParams
 ) {
     companion object : KLogging()
 
+    private fun <R> withSession(block: (DatabaseSessionEmbedded) -> R): R =
+        database.cachedPool(
+            params.databaseName,
+            params.appUser.name,
+            params.appUser.password,
+            params.youTrackDBConfig
+        ).acquire().use(block)
+
     fun compactDatabase() {
-        val databaseLocation = File(dbProvider.databaseLocation)
+        val databaseLocation = File(params.databasePath, params.databaseName)
         val backupFile = File(databaseLocation, "temp${System.currentTimeMillis()}")
         backupFile.parentFile.mkdirs()
         val listener = CommandOutputListener { iText -> logger.info("Compacting database: $iText") }
 
-        dbProvider.withSession { session ->
+        withSession { session ->
             val exporter = DatabaseExport(
-                session as DatabaseSessionEmbedded,
+                session,
                 backupFile.outputStream(),
                 listener
             )
@@ -47,22 +54,20 @@ class YTDBDatabaseCompacter(
         }
 
         logger.info("Dropping existing database...")
-        db.drop(params.databaseName)
+        database.drop(params.databaseName)
 
-        db.create(
+        database.create(
             params.databaseName,
             params.databaseType,
             params.appUser.name,
             params.appUser.password,
             "admin"
         )
-        // close the current graph and create a new one after the database drop and create
-        dbProvider.initGraph()
 
-        dbProvider.withSession { session ->
+        withSession { session ->
             logger.info("Importing database from dump")
             val importer = DatabaseImport(
-                session as DatabaseSessionEmbedded,
+                session,
                 backupFile.inputStream(),
                 listener
             )

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
@@ -22,6 +22,7 @@ import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl
 //import com.jetbrains.youtrackdb.internal.server.network.protocol.binary.NetworkProtocolBinary
 //import com.jetbrains.youtrackdb.internal.server.network.protocol.http.NetworkProtocolHttpDb
 //import com.jetbrains.youtrackdb.internal.tools.config.*
+import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseCompacter
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseParams
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProvider
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProviderImpl
@@ -110,10 +111,21 @@ object YTDBDatabaseProviderFactory {
 //                server.activate()
 //                Pair(server.context, server)
             }
-        return YTDBDatabaseProviderImpl(params, youTrackDb as YouTrackDBImpl)
+        return createProvider(params, youTrackDb)
     }
 
     fun createProvider(params: YTDBDatabaseParams, youTrackDB: YouTrackDB): YTDBDatabaseProvider {
-        return YTDBDatabaseProviderImpl(params, youTrackDB as YouTrackDBImpl)
+        val db = youTrackDB as YouTrackDBImpl
+        db.createIfNotExists(
+            params.databaseName,
+            params.databaseType,
+            params.appUser.name,
+            params.appUser.password,
+            "admin"
+        )
+        if (System.getProperty("exodus.env.compactOnOpen", "false").toBoolean()) {
+            YTDBDatabaseCompacter(db, params).compactDatabase()
+        }
+        return YTDBDatabaseProviderImpl(params, db)
     }
 }

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
@@ -21,6 +21,13 @@ import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBGraph
 interface YTDBDatabaseProvider {
     val databaseLocation: String
 
+    /**
+     * The single shared [YTDBGraph] instance backed by the session pool.
+     * The graph uses thread-local state internally, so each thread gets its own session.
+     *
+     * Must NOT be closed — [com.jetbrains.youtrackdb.internal.core.gremlin.YTDBGraphEmbedded.close]
+     * would close the shared pool.
+     */
     val graph: YTDBGraph
 
     fun <R> withSession(block: (DatabaseSessionEmbedded) -> R): R

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
@@ -16,6 +16,7 @@
 package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded
+import com.jetbrains.youtrackdb.internal.core.db.SessionPool
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl
 import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBGraph
 import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBGraphEmbedded
@@ -37,10 +38,7 @@ class YTDBDatabaseProviderImpl(
 
     companion object : KLogging()
 
-    private var _graph: YTDBGraph? = null
-
-    // _graph is always initialized in the constructor and never nullified
-    override val graph: YTDBGraph get() = _graph!!
+    override val graph: YTDBGraph
 
     init {
         val userNames = listOf(params.appUser.name) + params.additionalUsers.map { it.name }
@@ -55,12 +53,14 @@ class YTDBDatabaseProviderImpl(
             "admin"
         )
 
-        // ToDo: migrate to some config entity instead of System props
-        if (System.getProperty("exodus.env.compactOnOpen", "false").toBoolean()) {
-            compact()
-        }
+        val sessionPool = database.cachedPool(
+            params.databaseName,
+            params.appUser.name,
+            params.appUser.password,
+            params.youTrackDBConfig
+        )
+        graph = sessionPool.asGraph()
 
-        initGraph()
         if (params.additionalUsers.any()) {
             withSession { session ->
                 session.transaction { tx ->
@@ -88,28 +88,12 @@ class YTDBDatabaseProviderImpl(
         isOpen = true
     }
 
-    fun initGraph() {
-        _graph?.close()
-        _graph = database.cachedPool(
-            params.databaseName,
-            params.appUser.name,
-            params.appUser.password,
-            params.youTrackDBConfig
-        ).asGraph()
-    }
-
-    fun compact() {
-        YTDBDatabaseCompacter(database, this, params).compactDatabase()
-    }
 
     override val databaseLocation: String
         get() = File(params.databasePath, params.databaseName).absolutePath
 
-
     override fun <R> withSession(block: (DatabaseSessionEmbedded) -> R): R =
-        acquireSession().use(block)
-
-    private fun acquireSession(): DatabaseSessionEmbedded = (graph as YTDBGraphEmbedded).acquireSession()
+        (graph as YTDBGraphEmbedded).acquireSession().use(block)
 
     // it is always false at the beginning (it is impossible to close the database in the frozen state)
     private var _readOnly: Boolean = false

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
@@ -73,6 +73,38 @@ class YTDBPersistentEntityStore(
         return currentTx
     }
 
+    /**
+     * Suspends the current transaction, sets up an independent database context, and runs [block].
+     * On completion the previous transaction is restored, regardless of whether [block] succeeds
+     * or throws. Any transaction started inside [block] is fully isolated from the suspended one.
+     *
+     * This is the entity-store half of the `transactional(isNew = true)` mechanism — the caller
+     * is responsible for suspending/resuming the DNQ session.
+     */
+    fun <T> withSuspendedTransaction(block: () -> T): T {
+        val savedTx = suspendTransaction()
+        return try {
+            databaseProvider.graph.withSuspendedTransaction<T, RuntimeException> { block() }
+        } finally {
+            resumeTransaction(savedTx)
+        }
+    }
+
+    private fun suspendTransaction(): YTDBStoreTransaction? {
+        val tx = currentTransaction.get()
+        if (tx != null) currentTransaction.remove()
+        return tx
+    }
+
+    private fun resumeTransaction(tx: YTDBStoreTransaction?) {
+        if (tx != null) {
+            check(currentTransaction.get() == null) { "Cannot resume: a transaction is already active" }
+            currentTransaction.set(tx)
+        } else {
+            currentTransaction.remove()
+        }
+    }
+
     private fun onTransactionFinished(tx: YTDBStoreTransaction) {
         val get = currentTransaction.get()
         check(get == tx) {
@@ -131,7 +163,7 @@ class YTDBPersistentEntityStore(
 
     override fun registerCustomPropertyType(
         txn: StoreTransaction,
-        clazz: Class<out Comparable<Any?>>,
+        clazz: Class<out Comparable<*>>,
         binding: ComparableBinding
     ) {
         throw NotImplementedError()

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/DBCompactTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/DBCompactTest.kt
@@ -35,7 +35,7 @@ class DBCompactTest {
                 tx.createIssueImpl("Test issue $it")
             }
         }
-        (orientDb.provider as YTDBDatabaseProviderImpl).compact()
+        YTDBDatabaseCompacter(orientDb.database, orientDb.params).compactDatabase()
         orientDb.withStoreTx {
             val size = it.getAll(Issues.CLASS).size()
             Assert.assertEquals(100, size)

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
@@ -18,7 +18,6 @@ package jetbrains.exodus.entitystore.youtrackdb.testutil
 import YTDBDatabaseProviderFactory
 import YouTrackDBFactory
 import com.jetbrains.youtrackdb.api.DatabaseType
-import com.jetbrains.youtrackdb.api.YouTrackDB
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl
 import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBGraphEmbedded
@@ -41,13 +40,15 @@ class InMemoryYouTrackDB(
 
     lateinit var provider: YTDBDatabaseProvider
     lateinit var schemaBuddy: YTDBSchemaBuddyImpl
+    lateinit var params: YTDBDatabaseParams
+        private set
 
     val username = "admin"
     val password = "password"
     val dbName = "testDB"
 
     override fun before() {
-        val params = YTDBDatabaseParams.builder()
+        params = YTDBDatabaseParams.builder()
             .withDatabaseType(DatabaseType.MEMORY)
             .withDatabasePath(Files.createTempDirectory("youTrackDB_test").absolutePathString())
             .withAppUser(username, password)

--- a/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntityStore.kt
+++ b/dnq-open-api/src/main/kotlin/jetbrains/exodus/database/TransientEntityStore.kt
@@ -17,8 +17,8 @@ package jetbrains.exodus.database
 
 import jetbrains.exodus.entitystore.Entity
 import jetbrains.exodus.entitystore.EntityStore
-import jetbrains.exodus.entitystore.PersistentEntityStore
 import jetbrains.exodus.entitystore.QueryCancellingPolicy
+import jetbrains.exodus.entitystore.youtrackdb.YTDBPersistentEntityStore
 import jetbrains.exodus.query.QueryEngine
 import jetbrains.exodus.query.metadata.ModelMetaData
 
@@ -27,7 +27,7 @@ import jetbrains.exodus.query.metadata.ModelMetaData
  */
 interface TransientEntityStore : EntityStore, EntityStoreRefactorings {
 
-    val persistentStore: PersistentEntityStore
+    val persistentStore: YTDBPersistentEntityStore
 
     val threadSession: TransientStoreSession?
 
@@ -49,6 +49,18 @@ interface TransientEntityStore : EntityStore, EntityStoreRefactorings {
      * Resumes previously suspended session
      */
     fun resumeSession(session: TransientStoreSession?)
+
+    /**
+     * Suspends the current DNQ session for the duration of [block] and restores it afterwards.
+     */
+    fun <T> withSuspendedSession(block: () -> T): T {
+        val savedSession = suspendThreadSession()
+        try {
+            return block()
+        } finally {
+            resumeSession(savedSession)
+        }
+    }
 
     fun addListener(listener: TransientStoreSessionListener)
 
@@ -78,6 +90,7 @@ interface TransientEntityStore : EntityStore, EntityStoreRefactorings {
      */
     fun <T> transactional(
             readonly: Boolean = false,
+            isNew: Boolean = false,
             queryCancellingPolicy: QueryCancellingPolicy? = null,
             block: (TransientStoreSession) -> T
     ): T

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
@@ -18,20 +18,53 @@ package com.jetbrains.teamsys.dnq.database
 import jetbrains.exodus.database.TransientEntityStore
 import jetbrains.exodus.database.TransientStoreSession
 import jetbrains.exodus.entitystore.QueryCancellingPolicy
-import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
 import mu.KLogging
 
 internal object TransientEntityStoreExt : KLogging() {
     fun <T> transactional(
         store: TransientEntityStore,
+        isNew: Boolean = false,
         queryCancellingPolicy: QueryCancellingPolicy? = null,
         block: (TransientStoreSession) -> T
     ): T {
         val currentSession = store.threadSession
-        if (currentSession != null) {
-            return block(currentSession)
+        return when {
+            currentSession == null -> startNewAndRun(store, queryCancellingPolicy, block)
+            isNew -> suspendAndRun(store, queryCancellingPolicy, block)
+            else -> block(currentSession)
         }
+    }
 
+    /**
+     * Runs [block] in a new independent transaction while an outer transaction is active on the current thread.
+     *
+     * The outer DNQ session is suspended via [TransientEntityStore.withSuspendedSession]; the
+     * persistent-store transaction and active graph are suspended/restored by
+     * [YTDBPersistentEntityStore.withSuspendedTransaction]. The inner transaction gets its own
+     * [YTDBGraph][com.jetbrains.youtrackdb.internal.core.gremlin.YTDBGraph] instance so that
+     * commit/abort/revert inside [block] cannot affect the outer transaction.
+     */
+    private fun <T> suspendAndRun(
+        store: TransientEntityStore,
+        queryCancellingPolicy: QueryCancellingPolicy?,
+        block: (TransientStoreSession) -> T
+    ): T {
+        return store.withSuspendedSession {
+            store.persistentStore.withSuspendedTransaction {
+                startNewAndRun(store, queryCancellingPolicy, block)
+            }
+        }
+    }
+
+    /**
+     * Opens a new DNQ session (which starts a new persistent transaction),
+     * runs [block], and commits on success or aborts on exception.
+     */
+    private fun <T> startNewAndRun(
+        store: TransientEntityStore,
+        queryCancellingPolicy: QueryCancellingPolicy?,
+        block: (TransientStoreSession) -> T
+    ): T {
         try {
             val newSession = store.beginSession(queryCancellingPolicy)
             var wasEx = true

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
@@ -87,10 +87,11 @@ open class TransientEntityStoreImpl : TransientEntityStore {
 
     override fun <T> transactional(
         readonly: Boolean,
+        isNew: Boolean,
         queryCancellingPolicy: QueryCancellingPolicy?,
         block: (TransientStoreSession) -> T
     ): T = TransientEntityStoreExt.transactional(
-        this, queryCancellingPolicy, block
+        this, isNew, queryCancellingPolicy, block
     )
 
     override fun beginTransaction(): StoreTransaction {

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/YTDBDetachedVertex.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/YTDBDetachedVertex.kt
@@ -220,4 +220,8 @@ object YTDBEmptyGraph : YTDBGraph {
     override fun uuid(): UUID {
         throw UnsupportedOperationException("Not supported.")
     }
+
+    override fun <T, X : Exception> withSuspendedTransaction(supplier: org.apache.commons.lang3.function.FailableSupplier<T, X>): T {
+        throw UnsupportedOperationException("Not supported.")
+    }
 }

--- a/dnq-xodus-open-api/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStore.java
+++ b/dnq-xodus-open-api/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStore.java
@@ -112,7 +112,7 @@ public interface PersistentEntityStore extends EntityStore, Backupable {
      * @see jetbrains.exodus.ByteIterable
      */
     void registerCustomPropertyType(@NotNull final StoreTransaction txn,
-                                    @NotNull final Class<? extends Comparable> clazz,
+                                    @NotNull final Class<? extends Comparable<?>> clazz,
                                     @NotNull final ComparableBinding binding);
 
     /**

--- a/dnq/src/test/kotlin/kotlinx/dnq/DBTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/DBTest.kt
@@ -200,7 +200,7 @@ abstract class DBTest {
             readonly: Boolean = false,
             queryCancellingPolicy: QueryCancellingPolicy? = null,
             block: (TransientStoreSession) -> T
-    ) = store.transactional(readonly, queryCancellingPolicy, block)
+    ): T = store.transactional(readonly, false, queryCancellingPolicy, block)
 
     fun <XD : XdEntity> XdEntityType<XD>.onUpdate(mode: Where = SYNC_AFTER_FLUSH, action: (XD, XD) -> Unit): XdEntityListener<XD> {
         val listener = makeListener(mode, action)

--- a/dnq/src/test/kotlin/kotlinx/dnq/FindOrCreateTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/FindOrCreateTest.kt
@@ -233,7 +233,6 @@ class FindOrCreateTest : DBTest() {
                 start.await()
                 counter.value += 1
                 User.findOrNew(User.filter { it.login eq userName }) {
-                    println(user)
                     login = userName
                     skill = 456
                     supervisor = boss

--- a/dnq/src/test/kotlin/kotlinx/dnq/NewTransactionTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/NewTransactionTest.kt
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import com.google.common.truth.Truth.assertThat
+import jetbrains.exodus.entitystore.EntityRemovedInDatabaseException
+import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
+import kotlinx.dnq.query.first
+import kotlinx.dnq.query.toList
+import org.junit.Test
+
+class NewTransactionTest : DBTest() {
+
+    @Test(expected = EntityRemovedInDatabaseException::class)
+    fun `inner revert without isNew destroys outer transaction`() {
+        transactional { outerTxn ->
+            val user = User.new {
+                login = "outer-user"
+                skill = 1
+            }
+
+            // Without isNew, inner block reuses the outer session —
+            // revert wipes out the outer transaction's entity.
+            transactional { innerTxn ->
+                (innerTxn.transactionInternal as YTDBStoreTransaction).revert()
+            }
+
+            // This fails because the entity was reverted along with the outer session.
+            user.login
+        }
+    }
+
+    @Test
+    fun `inner isNew transaction revert does not affect outer transaction`() {
+        transactional { outerTxn ->
+            val user = User.new {
+                login = "outer-user"
+                skill = 1
+            }
+
+            store.transactional(isNew = true) { innerTxn ->
+                (innerTxn.transactionInternal as YTDBStoreTransaction).revert()
+            }
+
+            // The outer entity must survive the inner revert.
+            assertThat(user.login).isEqualTo("outer-user")
+        }
+    }
+
+    @Test
+    fun `inner isNew transaction abort does not affect outer transaction`() {
+        transactional { outerTxn ->
+            val user = User.new {
+                login = "outer-user"
+                skill = 1
+            }
+
+            store.transactional(isNew = true) { innerTxn ->
+                User.new {
+                    login = "inner-user"
+                    skill = 2
+                }
+                innerTxn.abort()
+            }
+
+            assertThat(user.login).isEqualTo("outer-user")
+        }
+    }
+
+    @Test
+    fun `inner isNew transaction commits independently of outer abort`() {
+        transactional { outerTxn ->
+            User.new {
+                login = "outer-user"
+                skill = 1
+            }
+
+            store.transactional(isNew = true) { innerTxn ->
+                User.new {
+                    login = "inner-user"
+                    skill = 2
+                }
+                // inner commits on block exit
+            }
+
+            // abort the outer transaction — inner commit must survive
+            outerTxn.abort()
+        }
+
+        transactional {
+            val logins = User.all().toList().map { it.login }
+            assertThat(logins).containsExactly("inner-user")
+        }
+    }
+
+    @Test
+    fun `double-nested isNew — second level abort does not affect first or third`() {
+        transactional { level1 ->
+            User.new { login = "level1"; skill = 1 }
+
+            store.transactional(isNew = true) { level2 ->
+                User.new { login = "level2"; skill = 2 }
+
+                store.transactional(isNew = true) { level3 ->
+                    User.new { login = "level3"; skill = 3 }
+                    // level3 commits
+                }
+
+                // abort level2 — level1 and level3 must be unaffected
+                level2.abort()
+            }
+
+            assertThat(User.new { login = "level1-after"; skill = 4 }.login).isEqualTo("level1-after")
+        }
+
+        transactional {
+            val logins = User.all().toList().map { it.login }.sorted()
+            assertThat(logins).containsExactly("level1", "level1-after", "level3")
+        }
+    }
+
+    @Test
+    fun `double-nested isNew — third level commits, all levels independent`() {
+        transactional { level1 ->
+            User.new { login = "level1"; skill = 1 }
+
+            store.transactional(isNew = true) { level2 ->
+                User.new { login = "level2"; skill = 2 }
+
+                store.transactional(isNew = true) { level3 ->
+                    User.new { login = "level3"; skill = 3 }
+                    // level3 commits normally
+                }
+
+                // level2 commits normally
+            }
+
+            User.new { login = "level1-after"; skill = 4 }
+        }
+
+        transactional {
+            val logins = User.all().toList().map { it.login }.sorted()
+            assertThat(logins).containsExactly("level1", "level1-after", "level2", "level3")
+        }
+    }
+
+    @Test
+    fun `double-nested isNew — third level abort does not affect first or second`() {
+        transactional { level1 ->
+            User.new { login = "level1"; skill = 1 }
+
+            store.transactional(isNew = true) { level2 ->
+                User.new { login = "level2"; skill = 2 }
+
+                store.transactional(isNew = true) { level3 ->
+                    User.new { login = "level3"; skill = 3 }
+                    // abort level3 — level1 and level2 must be unaffected
+                    level3.abort()
+                }
+
+                assertThat(User.new { login = "level2-after"; skill = 4 }.login).isEqualTo("level2-after")
+                // level2 commits
+            }
+
+            assertThat(User.new { login = "level1-after"; skill = 5 }.login).isEqualTo("level1-after")
+        }
+
+        transactional {
+            val logins = User.all().toList().map { it.login }.sorted()
+            assertThat(logins).containsExactly("level1", "level1-after", "level2", "level2-after")
+        }
+    }
+
+    @Test
+    fun `isNew without outer transaction works normally`() {
+        store.transactional(isNew = true) { txn ->
+            User.new {
+                login = "standalone"
+                skill = 1
+            }
+        }
+
+        transactional {
+            val user = User.all().first()
+            assertThat(user.login).isEqualTo("standalone")
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Adds an isNew flag to TransientEntityStore.transactional so callers can open a fresh, independent transaction while an outer transaction is active on the current thread — the outer session is suspended for the duration of block and resumed afterwards.
- Introduces withSuspendedSession on TransientEntityStore and a createGraph() hook on YTDBDatabaseProvider so suspended-session work runs on its own YTDBGraph with independent thread-local state.                                                                                                                                                                        
- Narrows TransientEntityStore.persistentStore type from PersistentEntityStore to YTDBPersistentEntityStore.
- Bumps YTDB snapshot to 0.5.0-20260416.230349-d5bf7fd-SNAPSHOT.
- Adds NewTransactionTest covering the independent-transaction semantics.
                                                                                                                                                                                             
###  Test plan

- NewTransactionTest passes
- Full dnq test suite passes against the new YTDB snapshot