### PR TITLE
Use LONGFILE_POSIX in tar backups

### DIFF
--- a/dnq-compress/src/main/java/jetbrains/exodus/util/CompressBackupUtil.java
+++ b/dnq-compress/src/main/java/jetbrains/exodus/util/CompressBackupUtil.java
@@ -182,7 +182,9 @@ public class CompressBackupUtil {
                 zipArchive.setLevel(Deflater.BEST_COMPRESSION);
                 archive = zipArchive;
             } else {
-                archive = new TarArchiveOutputStream(new GZIPOutputStream(output));
+                final TarArchiveOutputStream tar = new TarArchiveOutputStream(new GZIPOutputStream(output));
+                tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+                archive = tar;
             }
             try (ArchiveOutputStream aos = archive) {
                 for (final VirtualFileDescriptor fd : strategy.getContents()) {


### PR DESCRIPTION
## Summary

- YTDB generates composite-index file names (e.g. `CustomAttributeMapping_attributePrototype_targetEntityId_authModule_targetEntityId_unique_*.cbt`) that exceed the 100-byte ustar tar header limit.
- `CompressBackupUtil` currently aborts with `IOException: file name is too long` when creating a `.tar.gz` backup, because `TarArchiveOutputStream` defaults to `LONGFILE_ERROR`.
- Switch to `LONGFILE_POSIX` so long names are emitted as PAX extended headers. The resulting archive stays `.tar.gz` and is handled transparently by `tar xzf` / libarchive on restore.

## Test plan

- [x] Verified locally against Hub on YTDB: `BackupCreationTest > create backup and check that it is created` and `BackupCreationTest > change name prefix and type and create backup` both pass (previously failed with the 100-byte error).
- [x] Resulting `.tar.gz` contains the long-named `.cbt` / `.nbt` / `.ixs` entries and is listable with `tar tzf`.