### PR TITLE
XD-1266 Extend polymorphic query support

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies
 
 sealed class GremlinQuery {
 
@@ -278,6 +279,14 @@ sealed class GremlinQuery {
          * The graph reference is not needed: TinkerPop propagates it automatically when
          * the child traversal is integrated into the parent via `union()`.
          *
+         * The child's strategies container is replaced with a fresh [DefaultTraversalStrategies]
+         * before adding [optionsStrategy]. `__.start()` aliases its strategies field to the
+         * shared `TraversalStrategies.GlobalCache[EmptyGraph]` singleton; mutating it races
+         * across threads (`ConcurrentModificationException` in `sortStrategies`) and leaks
+         * options globally. A private container eliminates both issues — the child's
+         * strategies are only probed via `getStrategy(OptionsStrategy.class)` before
+         * TinkerPop's `lock()` overwrites them with the parent's.
+         *
          * `GraphTraversal.with()` cannot be used here: it is a step modulator (configures
          * the preceding step), not traversal-wide config. Anonymous traversals need the
          * [OptionsStrategy] set directly via the admin API.
@@ -292,7 +301,8 @@ sealed class GremlinQuery {
             subqueries.forEach { sq ->
                 val child = `__`.start<Any>()
                 if (optionsStrategy != null) {
-                    child.asAdmin().strategies.addStrategies(optionsStrategy)
+                    val admin = child.asAdmin()
+                    admin.strategies = DefaultTraversalStrategies().apply { addStrategies(optionsStrategy) }
                 }
                 val subRes = sq.continueTraversal(child.asYT(), c, sortApplied)
                 c = subRes.counter

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBPolymorphicQueryTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBPolymorphicQueryTest.kt
@@ -15,10 +15,13 @@
  */
 package jetbrains.exodus.entitystore.youtrackdb.iterate
 
-import com.google.common.truth.Truth.assertThat
 import jetbrains.exodus.entitystore.youtrackdb.getOrCreateVertexClass
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
+import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityId
+import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
 import jetbrains.exodus.entitystore.youtrackdb.testutil.*
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -566,6 +569,112 @@ class YTDBPolymorphicQueryTest : OTestMixin {
 
             val combined = nonPoly1.union(nonPoly2) // polymorphic=false
             assertFailsWith<IllegalArgumentException> { combined.intersect(poly) }
+        }
+    }
+
+    // --- ByIds mixed-polymorphic validation tests ---
+    // ByIds iterables are always polymorphic=true (default). Combining them with
+    // non-polymorphic iterables is rejected because the polymorphic flag propagates
+    // to child subtraversals and can cause the engine to silently drop results.
+
+    @Test
+    fun `ByIds with non-polymorphic minus throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val base1 = tx.find(BaseUser.CLASS, "name", "base1").first()!!
+            val byIds = YTDBEntityIterable.query(tx, GremlinQuery.ByIds(listOf((base1.id as YTDBEntityId).asOId())))
+
+            assertFailsWith<IllegalArgumentException> { nonPoly.minus(byIds) }
+        }
+    }
+
+    @Test
+    fun `ByIds with non-polymorphic intersect throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val base1 = tx.find(BaseUser.CLASS, "name", "base1").first()!!
+            val byIds = YTDBEntityIterable.query(tx, GremlinQuery.ByIds(listOf((base1.id as YTDBEntityId).asOId())))
+
+            assertFailsWith<IllegalArgumentException> { nonPoly.intersect(byIds) }
+        }
+    }
+
+    @Test
+    fun `ByIds with non-polymorphic union throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val nonPoly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val user1 = tx.find(User.CLASS, "name", "user1").first()!!
+            val byIds = YTDBEntityIterable.query(tx, GremlinQuery.ByIds(listOf((user1.id as YTDBEntityId).asOId())))
+
+            assertFailsWith<IllegalArgumentException> { nonPoly.union(byIds) }
+        }
+    }
+
+    @Test
+    fun `ByIds with polymorphic union works correctly`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val user1 = tx.find(User.CLASS, "name", "user1").first()!!
+            val byIds = YTDBEntityIterable.query(tx, GremlinQuery.ByIds(listOf((user1.id as YTDBEntityId).asOId())))
+
+            val intersected = poly.intersect(byIds)
+            assertNamesExactly(intersected, "user1")
+        }
+    }
+
+    @Test
+    fun `mixed-flag non-ByIds throws`() {
+        givenUserHierarchy()
+
+        withStoreTx { tx ->
+            val poly = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = true)
+            val nonPoly = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+
+            assertFailsWith<IllegalArgumentException> { poly.intersect(nonPoly) }
+            assertFailsWith<IllegalArgumentException> { nonPoly.union(poly) }
+        }
+    }
+
+    @Test
+    fun `UnionAll subtraversals does not mutate shared EmptyGraph strategies`() {
+        givenUserHierarchy()
+        // D9 invariant: GremlinQuery.UnionAll.subtraversals() must not mutate
+        // the TraversalStrategies.GlobalCache[EmptyGraph] container that
+        // anonymous traversals alias to. The CME observed under the pre-fix
+        // code was a symptom of this invariant being violated by concurrent
+        // addStrategies calls on the shared LinkedHashSet; testing the
+        // invariant directly catches the root cause deterministically,
+        // without needing to reproduce the race.
+        //
+        // The baseline snapshot is captured as a `List` and compared element-wise
+        // by identity (not by `equals`): AbstractTraversalStrategy.equals compares
+        // by class, so a same-class replacement of a pre-existing OptionsStrategy
+        // would pass a set-equality check while still violating the invariant.
+        val shared = TraversalStrategies.GlobalCache.getStrategies(EmptyGraph::class.java)
+        val baseline = shared.toList()
+        withStoreTx { tx ->
+            val a = YTDBEntityIterable.where(BaseUser.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            val b = YTDBEntityIterable.where(User.CLASS, tx, GremlinBlock.All, polymorphic = false)
+            a.union(b).count()
+        }
+        val post = shared.toList()
+        assertEquals(
+            baseline.size, post.size,
+            "UnionAll.subtraversals() changed the size of TraversalStrategies.GlobalCache[EmptyGraph]"
+        )
+        baseline.indices.forEach { i ->
+            assertSame(
+                baseline[i], post[i],
+                "UnionAll.subtraversals() replaced the strategy at index $i in TraversalStrategies.GlobalCache[EmptyGraph]"
+            )
         }
     }
 }

--- a/dnq-query/src/main/java/jetbrains/exodus/query/NodeBase.java
+++ b/dnq-query/src/main/java/jetbrains/exodus/query/NodeBase.java
@@ -43,9 +43,16 @@ public abstract class NodeBase {
     @Nonnull
     public abstract GremlinQuery getQuery();
 
+    public Iterable<Entity> instantiate(String entityType,
+                                       QueryEngine queryEngine,
+                                       ModelMetaData metaData) {
+        return instantiate(entityType, queryEngine, metaData, true);
+    }
+
     public abstract Iterable<Entity> instantiate(String entityType,
                                                  QueryEngine queryEngine,
-                                                 ModelMetaData metaData);
+                                                 ModelMetaData metaData,
+                                                 boolean polymorphic);
 
     public abstract NodeBase getClone();
 

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/BinaryNode.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/BinaryNode.kt
@@ -61,11 +61,13 @@ open class BinaryNode(
     override fun instantiate(
         entityType: String,
         queryEngine: QueryEngine,
-        metaData: ModelMetaData?
+        metaData: ModelMetaData?,
+        polymorphic: Boolean
     ): Iterable<Entity> =
         YTDBEntityIterable.query(
             queryEngine.oStore.requireActiveTransaction(),
-            query.then(GremlinBlock.HasLabel(entityType))
+            query.then(GremlinBlock.HasLabel(entityType)),
+            polymorphic
         )
 
     override fun getClone(): NodeBase =

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/LeafNode.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/LeafNode.kt
@@ -37,10 +37,12 @@ class LeafNode(private val query: GremlinQuery) : NodeBase() {
     override fun instantiate(
         entityType: String,
         queryEngine: QueryEngine,
-        metaData: ModelMetaData?
+        metaData: ModelMetaData?,
+        polymorphic: Boolean
     ): Iterable<Entity> = YTDBEntityIterable.query(
         queryEngine.oStore.requireActiveTransaction(),
-        query.then(GremlinBlock.HasLabel(entityType))
+        query.then(GremlinBlock.HasLabel(entityType)),
+        polymorphic
     )
 
     override fun getClone(): NodeBase = LeafNode(query)

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
@@ -62,11 +62,13 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
                     val sorted = applySort(tree, entityType, instance)
                     sorted as? EntityIterable ?: InMemoryEntityIterable(sorted, txn = persistentStore.andCheckCurrentTransaction, this)
                 } else {
+                    val polymorphic = (instance.unwrap() as? YTDBEntityIterable)?.polymorphic ?: true
                     instance.intersect(
                         tree.instantiate(
                             entityType,
                             this,
-                            modelMetaData
+                            modelMetaData,
+                            polymorphic
                         ) as EntityIterable
                     )
                 }

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/UnaryNode.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/UnaryNode.kt
@@ -50,10 +50,12 @@ class UnaryNode(
     override fun instantiate(
         entityType: String,
         queryEngine: QueryEngine,
-        metaData: ModelMetaData?
+        metaData: ModelMetaData?,
+        polymorphic: Boolean
     ): Iterable<Entity> = YTDBEntityIterable.query(
         queryEngine.oStore.requireActiveTransaction(),
-        query.then(GremlinBlock.HasLabel(entityType))
+        query.then(GremlinBlock.HasLabel(entityType)),
+        polymorphic
     )
 
     override fun getClone(): NodeBase = UnaryNode(child.clone, shortName, op)

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
@@ -675,7 +675,8 @@ private fun Iterable<Entity?>.filterNotNull(entityType: XdEntityType<*>): Iterab
             YTDBEntityIterable.where(
                 entityTypeName,
                 this.transaction.asYTDBTransaction(),
-                GremlinBlock.All
+                GremlinBlock.All,
+                this.polymorphic
             )
         )
     } else {

--- a/dnq/src/test/kotlin/kotlinx/dnq/XdEntityTypePolymorphicTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/XdEntityTypePolymorphicTest.kt
@@ -18,9 +18,14 @@ package kotlinx.dnq
 import com.google.common.truth.Truth.assertThat
 import com.jetbrains.teamsys.dnq.database.PersistentEntityIterableWrapper
 import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBEntityIterable
+import kotlinx.dnq.query.exclude
 import kotlinx.dnq.query.filter
+import kotlinx.dnq.query.filterIsInstance
+import kotlinx.dnq.query.filterIsNotInstance
+import kotlinx.dnq.query.plus
 import kotlinx.dnq.query.sortedBy
 import kotlinx.dnq.query.toList
+import kotlinx.dnq.query.union
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
@@ -114,23 +119,171 @@ class XdEntityTypePolymorphicTest : DBTest() {
     }
 
     @Test
-    fun `non-polymorphic all chained with filter throws due to polymorphic mismatch`() {
-        // filter() internally intersects the non-polymorphic instance with a
-        // default-polymorphic tree result from QueryEngine.query(), triggering
-        // Track 2's combination validation. This is a known limitation:
-        // filtering non-polymorphic queries requires lower-level APIs
-        // (YTDBStoreTransaction.find* with polymorphic=false).
+    fun `non-polymorphic all chained with filter returns only exact type instances`() {
         transactional {
+            User.new { login = "user1"; skill = 5 }
+            User.new { login = "user2"; skill = 1 }
+            User.new { login = "user3"; skill = 10 }
+        }
+
+        transactional(readonly = true) {
+            // QueryEngine.query() must match the tree result's polymorphic flag
+            // to the instance's flag before intersecting, otherwise
+            // requirePolymorphicMatch rejects the combination.
+            val result = User.all(polymorphic = false).filter {
+                it.skill gt 3
+            }.toList()
+            assertThat(result.map { it.login }).containsExactly("user1", "user3")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all with filter on hierarchy base type returns empty`() {
+        transactional {
+            val user = User.new { login = "owner"; skill = 1 }
+            val root = RootGroup.new { name = "rootGroup" }
+            NestedGroup.new { name = "nestedGroup"; parentGroup = root; owner = user }
+        }
+
+        transactional(readonly = true) {
+            // Filtering non-polymorphic all() on an abstract base should still
+            // return empty — no concrete instances of Group exist.
+            val result = Group.all(polymorphic = false).filter {
+                it.name eq "rootGroup"
+            }.toList()
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all with filterIsInstance returns only matching subtype`() {
+        transactional {
+            val user = User.new { login = "owner"; skill = 1 }
+            val root = RootGroup.new { name = "rootGroup" }
+            NestedGroup.new { name = "nestedGroup"; parentGroup = root; owner = user }
+        }
+
+        transactional(readonly = true) {
+            // Non-polymorphic all on Group (abstract) returns empty,
+            // so filterIsInstance on it should also return empty
+            val result = Group.all(polymorphic = false).filterIsInstance(RootGroup).toList()
+            assertThat(result).isEmpty()
+
+            // Polymorphic all on Group returns all subtypes,
+            // filterIsInstance narrows to RootGroup only
+            val polyResult = Group.all().filterIsInstance(RootGroup).toList()
+            assertThat(polyResult).hasSize(1)
+            assertThat(polyResult.map { it.name }).containsExactly("rootGroup")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all with filterIsNotInstance excludes matching subtype`() {
+        transactional {
+            val user = User.new { login = "owner"; skill = 1 }
+            val root = RootGroup.new { name = "rootGroup" }
+            NestedGroup.new { name = "nestedGroup"; parentGroup = root; owner = user }
+        }
+
+        transactional(readonly = true) {
+            // Non-polymorphic all on Group (abstract) returns empty,
+            // so filterIsNotInstance should also return empty
+            val result = Group.all(polymorphic = false).filterIsNotInstance(RootGroup).toList()
+            assertThat(result).isEmpty()
+
+            // Polymorphic all on Group returns all subtypes,
+            // filterIsNotInstance excludes RootGroup, leaving only NestedGroup
+            val polyResult = Group.all().filterIsNotInstance(RootGroup).toList()
+            assertThat(polyResult).hasSize(1)
+            assertThat(polyResult.map { it.name }).containsExactly("nestedGroup")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all on concrete type with filterIsInstance exercises real intersect`() {
+        transactional {
+            val user = User.new { login = "owner"; skill = 1 }
+            val root = RootGroup.new { name = "rootGroup" }
+            NestedGroup.new { name = "nestedGroup"; parentGroup = root; owner = user }
+        }
+
+        transactional(readonly = true) {
+            // Non-polymorphic all on RootGroup (concrete) returns real instances,
+            // so filterIsInstance actually exercises the intersect path
+            val result = RootGroup.all(polymorphic = false).filterIsInstance(RootGroup).toList()
+            assertThat(result.map { it.name }).containsExactly("rootGroup")
+
+            // filterIsNotInstance(NestedGroup) on non-polymorphic RootGroup keeps all RootGroups
+            val notNestedResult = RootGroup.all(polymorphic = false).filterIsNotInstance(NestedGroup).toList()
+            assertThat(notNestedResult.map { it.name }).containsExactly("rootGroup")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all with chained filters preserves polymorphic flag`() {
+        transactional {
+            User.new { login = "user1"; skill = 5 }
+            User.new { login = "user2"; skill = 1 }
+            User.new { login = "user3"; skill = 10 }
+        }
+
+        transactional(readonly = true) {
+            val result = User.all(polymorphic = false)
+                .filter { it.skill gt 0 }
+                .filter { it.skill gt 3 }
+                .toList()
+            assertThat(result.map { it.login }).containsExactly("user1", "user3")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all exclude single entity throws`() {
+        val user1 = transactional {
+            User.new { login = "user1"; skill = 5 }
+        }
+        transactional {
+            User.new { login = "user2"; skill = 1 }
+        }
+
+        transactional(readonly = true) {
+            // exclude(entity) wraps the entity in queryOf() which creates a ByIds
+            // iterable (default polymorphic=true). Mixing polymorphic flags is rejected.
+            assertFailsWith<IllegalArgumentException> {
+                User.all(polymorphic = false).exclude(user1).toList()
+            }
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all union single entity throws`() {
+        val user1 = transactional {
             User.new { login = "user1"; skill = 5 }
         }
 
         transactional(readonly = true) {
-            val exception = assertFailsWith<IllegalArgumentException> {
-                User.all(polymorphic = false).filter {
-                    it.skill gt 3
-                }.toList()
+            // union(entity) wraps in queryOf() → ByIds (polymorphic=true).
+            // Mixing polymorphic flags is rejected.
+            assertFailsWith<IllegalArgumentException> {
+                (User.all(polymorphic = false) union user1).toList()
             }
-            assertThat(exception.message).contains("non-polymorphic")
+        }
+    }
+
+    @Test
+    fun `non-polymorphic all plus single entity throws`() {
+        val user1 = transactional {
+            User.new { login = "user1"; skill = 5 }
+        }
+        transactional {
+            User.new { login = "user2"; skill = 1 }
+        }
+
+        transactional(readonly = true) {
+            // plus(entity) wraps in queryOf() → ByIds (polymorphic=true).
+            // Mixing polymorphic flags is rejected.
+            assertFailsWith<IllegalArgumentException> {
+                (User.all(polymorphic = false) + user1).toList()
+            }
         }
     }
 

--- a/docs/adr/polymorphic-queries/adr.md
+++ b/docs/adr/polymorphic-queries/adr.md
@@ -26,8 +26,12 @@ optimizer path.
 
 - **Fail-fast on mixed-flag combinations:** Reject at combination time any
   attempt to merge a polymorphic iterable with a non-polymorphic one.
-  *Achieved as planned.* The validation also catches unintended mixing
-  through DNQ query extensions (e.g., `filter()` on a non-polymorphic query).
+  *Achieved as planned.* `EMPTY` short-circuits before the check.
+  `ByIds` queries (default `polymorphic = true`) are subject to the same
+  validation — no bypass. Internal flag propagation through
+  `QueryEngine.query()` (D7) ensures
+  `filter()`/`filterIsInstance()`/`filterIsNotInstance()` produce
+  flag-consistent operands.
 
 ## Constraints
 
@@ -152,10 +156,10 @@ flowchart LR
   (C) Split into two traversals.
 - **Decision:** Option B — explicit, safe, caller-visible.
 - **Outcome:** Implemented as planned via `requirePolymorphicMatch()`.
-  The validation also caught an unintended interaction: `filter()` on a
-  non-polymorphic query triggers the check because `QueryEngine.query()`
-  internally intersects with a default-polymorphic filter predicate.
-  This fail-fast behavior is correct — it prevents silently wrong results.
+  The validation rejects all combinations of iterables with different
+  polymorphic flags, including `ByIds` queries (see D8 revision).
+  Internal combinations are handled by D7 (flag propagation through
+  `NodeBase.instantiate()` in `QueryEngine.query()`).
 
 #### D3: Default parameter values preserve backward compatibility
 - **Alternatives considered:** (A) New method overloads.
@@ -181,6 +185,12 @@ flowchart LR
   `.with()` call per traversal, which is negligible.
 
 #### D5: Propagate OptionsStrategy to anonymous child traversals (emerged during Track 5)
+
+> **Superseded by D9** — the `addStrategies(optionsStrategy)` mechanism
+> described below is concurrent-unsafe. D9 (Track 7) revises the mechanism
+> to assign a fresh private `DefaultTraversalStrategies` to the child
+> before propagating. Body kept as historical record.
+
 - **Context:** `GremlinQuery.UnionAll.subtraversals()` originally created
   anonymous child traversals via `__.start()` without the parent's
   `OptionsStrategy`. `YTDBGraphStepStrategy` requires it to read
@@ -210,6 +220,153 @@ flowchart LR
   union result, not on each branch) avoids the OR-merge behavior while
   correctly filtering the combined result.
 
+#### D7: Propagate polymorphic flag through NodeBase.instantiate() (Track 6)
+- **Context:** `QueryEngine.query(instance, entityType, tree)` intersects
+  `instance` with `tree.instantiate(...)`. When `instance` is non-polymorphic,
+  the tree result was always polymorphic (default `true`), causing
+  `requirePolymorphicMatch()` to reject the combination. This broke
+  `filter()`, `filterIsInstance()`, and `filterIsNotInstance()` on
+  non-polymorphic queries.
+- **Alternatives considered:** (A) Add `polymorphic` parameter to
+  `NodeBase.instantiate()`. (B) Relax `requirePolymorphicMatch()` for
+  internal combinations. (C) Extract the query from the tree result and
+  recreate it with the instance's flag.
+- **Decision:** Option A — add a 4-parameter abstract
+  `instantiate(entityType, queryEngine, metaData, polymorphic)` to
+  `NodeBase` (Java). The 3-parameter method becomes concrete, delegating
+  with `polymorphic = true`. `QueryEngine.query()` extracts the flag from
+  `instance` via `(instance.unwrap() as? YTDBEntityIterable)?.polymorphic ?: true`
+  and passes it to the 4-parameter `tree.instantiate()`.
+- **Rationale:** Propagating through the creation path is consistent with
+  how `polymorphic` flows through `YTDBStoreTransaction` methods (D3).
+  Option B would remove the safety check for explicit user-level
+  combinations. Option C creates a "create wrong then fix" pattern.
+
+#### D8: ByIds queries are subject to requirePolymorphicMatch (Track 6, revised)
+- **Context:** DNQ single-entity operations (`exclude(entity)`,
+  `union(entity)`, `plus(entity)`) delegate to `queryOf()` which creates
+  a `ByIds` iterable with default `polymorphic = true`. When the left
+  operand is non-polymorphic (e.g., from `all(polymorphic = false)`),
+  `requirePolymorphicMatch()` rejects the combination.
+- **Initial decision (now reverted):** Bypass `requirePolymorphicMatch`
+  for `ByIds` queries, treating them as flag-neutral sentinels (like
+  `EMPTY`). The rationale was that `ByIds` looks up entities by ID, not
+  by label, so the `polymorphicQuery` config should be irrelevant.
+- **Why reverted:** While `ByIds` itself is ID-based, the `polymorphic`
+  flag on the combined result iterable propagates to the traversal
+  source's `OptionsStrategy`. For `union()`/`concat()` (which use
+  `UnionAll`), this `OptionsStrategy` propagates to anonymous child
+  subtraversals (Track 5 fix), causing the YouTrackDB engine to silently
+  drop results from the `ByIds` branch under `polymorphicQuery=false`.
+  Even for `intersect()`/`minus()` (which use `Aggregate` and are
+  technically unaffected), allowing a silent flag mismatch is
+  inconsistent and error-prone.
+- **Current decision:** No bypass — `ByIds` queries with
+  `polymorphic = true` (the default) cannot be combined with
+  non-polymorphic iterables. `requirePolymorphicMatch()` throws
+  `IllegalArgumentException` uniformly for all flag mismatches.
+  Callers that need to combine `ByIds` with non-polymorphic iterables
+  must ensure both operands have matching flags.
+- **Rationale:** Fail-fast is safer than silent data loss. The bypass
+  was originally added to support `exclude(entity)`, `union(entity)`,
+  and `plus(entity)` on non-polymorphic queries, but these patterns
+  silently lost results in the `union`/`concat` path. Rejecting the
+  combination forces callers to handle the flag explicitly.
+
+#### D9: Use a private strategies container for UnionAll anonymous children (Track 7 — revises D5)
+
+- **Context:** D5's original mechanism called
+  `child.asAdmin().strategies.addStrategies(optionsStrategy)` on
+  anonymous child traversals created via `__.start<Any>()`. In TinkerPop,
+  `__.start()` instantiates a `DefaultGraphTraversal()` whose
+  `strategies` field is **aliased** to the process-wide singleton
+  returned by `TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class)`
+  (`DefaultTraversal.java:103`). Concurrent `addStrategies` calls from
+  multiple threads raced on the underlying `LinkedHashSet` and threw
+  `ConcurrentModificationException` from
+  `DefaultTraversalStrategies.sortStrategies`. The mechanism also
+  permanently leaked every `OptionsStrategy` instance ever propagated
+  into the global cache. The bug surfaced as a
+  `ConcurrentModificationException` in the YouTrack/youtrackdb-migration
+  project under normal concurrent request load.
+- **Alternatives considered:**
+  1. `clone()` the aliased strategies, then add `OptionsStrategy`. Works,
+     but clones an empty global container — conceptually awkward; same
+     end-state as allocating a fresh empty container, with less clear
+     intent.
+  2. Use `DefaultGraphTraversal(gs)` (non-anonymous, inherits strategies
+     from the source) for the child. Only works in `startTraversal(gs)`;
+     `continueTraversal(parent, …)` has no source — would create
+     asymmetric code paths and still alias a shared container.
+  3. Fix on the consumer side — change YouTrackDB's
+     `YTDBStrategyUtil.isPolymorphic(traversal)` to read `OptionsStrategy`
+     from the root via `TraversalHelper.getRootTraversal(traversal)`.
+     Eliminates child-level strategy mutation entirely; architecturally
+     cleanest. Requires a coordinated cross-repo change; deferred as
+     future work.
+  4. Synchronize on the shared strategies object before
+     `addStrategies`. Fixes the CME but not the permanent global-cache
+     pollution; rejected.
+- **Decision:** Replace the child's `strategies` field with a freshly
+  allocated `DefaultTraversalStrategies` holding only the
+  `OptionsStrategy`. The child's `strategies` field is reassigned (via
+  the `Traversal.Admin` SPI) **before** any `addStrategies` call, so the
+  alias to the shared global is broken immediately and no shared state
+  is ever written to.
+- **Rationale:** Works because child traversals' strategies are only
+  read — never iterated — during strategy application
+  (`DefaultTraversal.applyStrategies` iterates only when `isRoot()`, see
+  `DefaultTraversal.java:144`). Provider strategies like
+  `YTDBGraphStepStrategy` call `child.getStrategies().getStrategy(OptionsStrategy.class)`
+  once to read `polymorphicQuery`. Immediately after strategy
+  application, `lock()` overwrites the child's `strategies` with the
+  parent's (`DefaultTraversal.java:338`), so the private container's
+  lifetime is bounded to a single pass. `EmptyGraph`'s default strategies
+  are empty (`TraversalStrategies.java:292`), so a fresh container
+  provides the same starting state as the original alias.
+- **Risks/Caveats:** The correctness argument depends on three
+  TinkerPop implementation facts. **A TinkerPop (and youtrackdb-core)
+  upgrade must re-verify each of them:**
+  1. `DefaultTraversal()`'s no-arg constructor aliases
+     `TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class)`
+     (i.e., the field is assigned by reference, not copied).
+  2. `DefaultTraversal.applyStrategies` iterates its `strategies`
+     field only when `isRoot()` holds — non-root (child) traversals
+     never iterate their own strategies during strategy application.
+  3. `DefaultTraversal.lock()` overwrites non-root child strategies
+     with `parentTraversal.getStrategies()` before strategy
+     application returns, bounding the lifetime of the private
+     container to a single strategy-application pass.
+
+  If any of these facts changes, the correctness of the mechanism
+  must be re-evaluated; the consumer-side read-from-root approach
+  (Alternative 3 above) becomes the natural next step.
+
+  **Future work (recommended forward direction):** Alternative 3 —
+  changing YouTrackDB's `YTDBStrategyUtil.isPolymorphic` to read
+  `OptionsStrategy` from the root via
+  `TraversalHelper.getRootTraversal(traversal)` — remains the
+  architecturally cleanest long-term fix. Any follow-up regression in
+  this area should pursue it rather than further complicating the
+  child-side propagation.
+- **Regression test:**
+  `YTDBPolymorphicQueryTest."UnionAll subtraversals does not mutate shared
+  EmptyGraph strategies"` — single-threaded structural check. Snapshots
+  `TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class)` at
+  test entry, runs one `union(a, b).count()` on two non-polymorphic label
+  queries, and asserts the strategy list is unchanged index-by-index by
+  reference identity (`===`). This tests the D9 invariant directly — the
+  `ConcurrentModificationException` observed under the pre-fix code was a
+  symptom of the same shared-container mutation this assertion catches,
+  so reproducing the race is unnecessary. The pre-fix
+  `child.asAdmin().strategies.addStrategies(optionsStrategy)` call would
+  either insert a new `OptionsStrategy` (when the cache starts clean) or
+  replace a pre-existing one (since `addStrategies` removes any same-class
+  incumbent first); the index-by-identity comparison detects both. Class
+  equality alone — `AbstractTraversalStrategy.equals` compares by class —
+  would hide the replacement case if the shared cache is already polluted
+  from a prior test in the same JVM fork.
+
 ### Invariants
 
 - A `YTDBEntityIterableImpl` with `polymorphic = false` produces a traversal
@@ -218,11 +375,19 @@ flowchart LR
   with `YTDBQueryConfigParam.polymorphicQuery = true` (explicitly set, not
   relying on default).
 - Combining two `YTDBEntityIterableImpl` with different `polymorphic` values
-  via `intersect`/`union`/`minus`/`concat` throws `IllegalArgumentException`.
+  via `intersect`/`union`/`minus`/`concat` throws `IllegalArgumentException`
+  — no exceptions, including `ByIds` queries (see D8 revision).
 - `YTDBEntityIterable.EMPTY` is compatible with either flag value (combination
   methods short-circuit before the flag check).
 - Single-operand transforms propagate `this.polymorphic`; `findLinks()`
   propagates `entities.polymorphic`.
+- `QueryEngine.query()` matches the tree result's polymorphic flag to the
+  instance's flag before intersecting — `filter()`, `filterIsInstance()`,
+  and `filterIsNotInstance()` work correctly on non-polymorphic queries.
+- `UnionAll.subtraversals()` does not mutate any strategies container
+  that it did not privately allocate (D9). Concurrent UnionAll queries
+  must not throw `ConcurrentModificationException` — enforced by the
+  regression test cited in D9.
 - All existing tests pass without modification.
 
 ### Non-Goals
@@ -256,12 +421,15 @@ flowchart LR
    method with the explicit `polymorphic` parameter. Non-override methods
    use Kotlin default parameters directly. (Track 3, Step 1)
 
-4. **`filter()` on non-polymorphic queries throws.** `QueryEngine.query()`
-   internally intersects the non-polymorphic iterable with a
-   default-polymorphic filter predicate iterable. The combination validation
-   catches this mismatch and throws `IllegalArgumentException`. Users
-   requiring filtered non-polymorphic results should use
-   `YTDBStoreTransaction.find*()` methods directly. (Track 4, Step 2)
+4. **`filter()` on non-polymorphic queries — initially threw, fixed in Track 6.**
+   `QueryEngine.query()` internally intersects the non-polymorphic iterable
+   with a tree-instantiated iterable. Before Track 6, `NodeBase.instantiate()`
+   always produced polymorphic iterables (default `true`), causing
+   `requirePolymorphicMatch()` to reject the combination. Track 6 adds a
+   `polymorphic` parameter to `NodeBase.instantiate()` and wires it through
+   `QueryEngine.query()`, resolving the mismatch. `filter()`,
+   `filterIsInstance()`, and `filterIsNotInstance()` now work correctly on
+   non-polymorphic queries. (Track 4, Step 2; fixed in Track 6)
 
 5. **`sortedBy()` flag reverts to `true`.** `SortEngine.sort()` creates a
    new iterable via `txn.sort()` which defaults to `polymorphic = true`.
@@ -309,3 +477,41 @@ flowchart LR
     the O7 double-label guard (falls to Aggregate), the O20b label placement
     (different traversal level), and the O19 `extractCondition` guard.
     (Track 5, Step 2)
+
+11. **`ByIds` queries cannot be safely combined with non-polymorphic
+    iterables.** DNQ single-entity operations (`exclude(entity)`,
+    `union(entity)`, `plus(entity)`) wrap the entity via `queryOf()` which
+    creates a `ByIds` iterable with default `polymorphic = true`. While
+    `ByIds` itself looks up entities by ID (not by label), the `polymorphic`
+    flag on the combined result propagates to the traversal source's
+    `OptionsStrategy`. For `union`/`concat` (which use `UnionAll`), this
+    `OptionsStrategy` propagates to anonymous child subtraversals (Track 5),
+    causing the engine to silently drop `ByIds` results under
+    `polymorphicQuery=false`. An initial bypass (treating `ByIds` as
+    flag-neutral) was reverted because it masked this silent data loss.
+    `requirePolymorphicMatch()` now rejects all flag mismatches uniformly,
+    including `ByIds`. The private `filterNotNull(entityType)` in
+    `XdQuery.kt` had a related issue: it called `YTDBEntityIterable.where()`
+    without passing `this.polymorphic`, creating a default-polymorphic
+    iterable that would fail the flag check when intersected with a
+    non-polymorphic receiver — fixed by propagating `this.polymorphic`.
+    (Track 6, revised)
+
+12. **TinkerPop's `__.start()` aliases the `EmptyGraph` global strategies
+    cache.** `DefaultTraversal()`'s no-arg constructor sets
+    `this.strategies = TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class)`
+    by reference (`DefaultTraversal.java:103`). Every anonymous traversal
+    in the JVM points at the same `DefaultTraversalStrategies` instance.
+    Track 5's original D5 mechanism
+    (`child.asAdmin().strategies.addStrategies(optionsStrategy)`) mutated
+    this shared singleton, racing across threads on the backing
+    `LinkedHashSet` and throwing `ConcurrentModificationException` from
+    `DefaultTraversalStrategies.sortStrategies`. The same mutation also
+    permanently accumulated every `OptionsStrategy` instance into the
+    global cache. Track 7 (D9) breaks the alias by assigning a fresh
+    private `DefaultTraversalStrategies` to the child before any
+    `addStrategies` call. The correctness argument relies on three
+    TinkerPop facts: the `EmptyGraph` alias, that `applyStrategies`
+    iterates strategies only on root traversals, and that `lock()`
+    overwrites child strategies with the parent's after strategy
+    application. (Track 7)

--- a/docs/adr/polymorphic-queries/design-final.md
+++ b/docs/adr/polymorphic-queries/design-final.md
@@ -106,7 +106,9 @@ instances propagate the flag: `modify()` (used by `skip`, `take`, `distinct`,
 `reverse`), `selectMany()`, and combination methods (`intersect`, `union`,
 `minus`, `concat`). `findLinks(entities, linkName)` propagates from the
 `entities` parameter (not `this`) because the result's query tree is built
-from `entities.query`.
+from `entities.query`. `requirePolymorphicMatch()` validates flag consistency
+for all combinations — no bypass for any query type. `EMPTY` short-circuits
+before the check (combination methods return early).
 
 **PersistentEntityIterableWrapper** delegates `polymorphic` to the unwrapped
 inner iterable: `(unwrap() as? YTDBEntityIterable)?.polymorphic ?: true`.
@@ -188,9 +190,12 @@ flowchart TD
     E -->|no| ERR
 ```
 
-All four combination methods follow the same pattern. The `EMPTY`
-short-circuit executes before the flag check — `EMPTY` is always compatible.
-`intersectSavingOrder` delegates to `intersect()` and inherits the check.
+All four combination methods follow the same pattern. `EMPTY` short-circuits
+before the flag check. All other operands — including `ByIds` queries — are
+subject to `requirePolymorphicMatch()`, which throws
+`IllegalArgumentException` on any flag mismatch (see D8 revision in
+`adr.md`). `intersectSavingOrder` delegates to `intersect()` and inherits
+the check.
 
 ### Flag propagation through single-operand transforms
 
@@ -212,44 +217,134 @@ passes `this.polymorphic`. `findLinks()` is the exception: the result's
 query tree starts from `entities.query`, so it propagates
 `entities.asYTDBIterable().polymorphic`.
 
-## Known limitations at the DNQ level
+## Query tree polymorphic propagation (D7)
 
-Two limitations exist when combining non-polymorphic queries with DNQ
-query extensions:
+When DNQ query extensions like `filter()`, `filterIsInstance()`, and
+`filterIsNotInstance()` are applied to a non-polymorphic query,
+`QueryEngine.query()` must ensure the filter tree produces an iterable
+with a matching polymorphic flag. Without this, the subsequent
+`intersect()` would be rejected by `requirePolymorphicMatch()`.
 
-1. **`filter()` throws `IllegalArgumentException`** — `QueryEngine.query()`
-   internally intersects the non-polymorphic iterable instance with a
-   default-polymorphic filter predicate iterable. Track 2's combination
-   validation catches the flag mismatch and rejects it. Users requiring
-   filtered non-polymorphic results should use `YTDBStoreTransaction.find*()`
-   methods with `polymorphic = false` directly.
+```mermaid
+classDiagram
+    class NodeBase {
+        <<abstract>>
+        +instantiate(entityType, queryEngine, metaData): Iterable~Entity~
+        +instantiate(entityType, queryEngine, metaData, polymorphic)*: Iterable~Entity~
+    }
 
-2. **`sortedBy()` flag reverts to `true`** — `SortEngine.sort()` creates a
-   new iterable via `txn.sort()` which defaults to `polymorphic = true`. The
-   sorted result content is correct (only exact-type instances appear), but
-   the flag on the resulting iterable is `true`. This means a subsequent
-   combination with a non-polymorphic iterable would not throw, even though
-   semantically the results came from a non-polymorphic query.
+    class LeafNode {
+        +instantiate(..., polymorphic): Iterable~Entity~
+    }
 
-Neither limitation affects the primary use case: `all(polymorphic = false)`
-for exact-type queries, with further filtering done at the transaction level.
+    class BinaryNode {
+        +instantiate(..., polymorphic): Iterable~Entity~
+    }
+
+    class UnaryNode {
+        +instantiate(..., polymorphic): Iterable~Entity~
+    }
+
+    NodeBase <|-- LeafNode
+    NodeBase <|-- BinaryNode
+    NodeBase <|-- UnaryNode
+    LeafNode ..> YTDBEntityIterable : query(tx, q, polymorphic)
+    BinaryNode ..> YTDBEntityIterable : query(tx, q, polymorphic)
+    UnaryNode ..> YTDBEntityIterable : query(tx, q, polymorphic)
+```
+
+`NodeBase` is a Java abstract class — Kotlin default parameters are not
+available. The 3-parameter `instantiate()` is concrete and delegates with
+`polymorphic = true`. The 4-parameter method is abstract. All three Kotlin
+subclasses override the 4-parameter method and pass `polymorphic` through
+to `YTDBEntityIterable.query()`. This pattern preserves backward
+compatibility for the two call sites in `QueryEngine.query()` that don't
+need the flag (null-instance and in-memory paths).
+
+```mermaid
+sequenceDiagram
+    participant Caller as filter() / filterIsInstance()
+    participant QE as QueryEngine.query()
+    participant Node as NodeBase.instantiate()
+    participant YEI as YTDBEntityIterable.query()
+    participant YEII as YTDBEntityIterableImpl
+
+    Caller->>QE: query(instance[poly=false], entityType, tree)
+    QE->>QE: polymorphic = instance.unwrap().polymorphic → false
+    QE->>Node: tree.instantiate(entityType, this, metaData, false)
+    Node->>YEI: query(tx, query.then(HasLabel), false)
+    YEI-->>Node: treeResult[poly=false]
+    Node-->>QE: treeResult[poly=false]
+    QE->>YEII: instance.intersect(treeResult)
+    YEII->>YEII: requirePolymorphicMatch → false == false ✓
+    YEII-->>Caller: combined result
+```
+
+`QueryEngine.query()` extracts the polymorphic flag from `instance` via
+`(instance.unwrap() as? YTDBEntityIterable)?.polymorphic ?: true` and
+passes it to the 4-parameter `tree.instantiate()`. The flag flows through
+the node tree and into iterable creation, ensuring both operands of the
+final `intersect()` have the same flag. Only the `else` branch (non-SortBy
+path) uses the 4-parameter overload — the SortBy branch bypasses
+`intersect()` entirely.
+
+## Known limitations and mitigations at the DNQ level
+
+One limitation exists when combining non-polymorphic queries with DNQ
+query extensions; the remaining operations are fully mitigated:
+
+**`sortedBy()` flag reverts to `true`** — `SortEngine.sort()` creates a
+new iterable via `txn.sort()` which defaults to `polymorphic = true`. The
+sorted result content is correct (only exact-type instances appear), but
+the flag on the resulting iterable is `true`. This means a subsequent
+combination with a non-polymorphic iterable would not throw, even though
+semantically the results came from a non-polymorphic query.
+
+`filter()`, `filterIsInstance()`, and `filterIsNotInstance()` work correctly
+on non-polymorphic queries — `QueryEngine.query()` propagates the polymorphic
+flag from the instance iterable through `NodeBase.instantiate()` to the tree
+result, ensuring flag-consistent intersection (see D7).
+
+**DNQ single-entity operations (`exclude(entity)`, `union(entity)`,
+`plus(entity)`) throw on non-polymorphic queries.** These delegate to
+`queryOf()` which creates a `ByIds` iterable with default
+`polymorphic = true`. When combined with a non-polymorphic iterable,
+`requirePolymorphicMatch()` rejects the flag mismatch. This is intentional
+— an earlier bypass (D8 initial version) silently lost results in the
+`union`/`concat` path because `UnionAll` propagates `OptionsStrategy`
+(including `polymorphicQuery=false`) to anonymous child subtraversals,
+causing the engine to drop `ByIds` results. Fail-fast is safer than
+silent data loss.
+
+The private `filterNotNull(entityType)` extension in `XdQuery.kt` propagates
+`this.polymorphic` to the `YTDBEntityIterable.where()` call used for the
+intersection, ensuring flag-consistent combination.
 
 ## Gremlin query optimizer interaction
 
 Two engine-level issues affect non-polymorphic queries in combination
 operations. Both are fully mitigated at the xodus-dnq layer.
 
-**Strategy propagation in UnionAll (fixed in Track 5).**
+**Strategy propagation in UnionAll (fixed in Track 5, revised in Track 7).**
 The YouTrackDB engine does not propagate `polymorphicQuery` config from the
 traversal source to anonymous child traversals inside `union()` steps. This
 caused `union()`/`concat()` on non-polymorphic queries with inherited types
 to return polymorphic results. Track 5 fixes this in
-`GremlinQuery.UnionAll.subtraversals()` by adding the parent's
-`OptionsStrategy` onto each anonymous child traversal. Only `OptionsStrategy`
+`GremlinQuery.UnionAll.subtraversals()` by attaching the parent's
+`OptionsStrategy` to each anonymous child traversal. Only `OptionsStrategy`
 is propagated — not the full strategy list — to avoid interfering with
 TinkerPop's own strategy application. The graph reference is not needed:
 TinkerPop propagates it automatically when the child is integrated into the
 parent via `union()`.
+
+The original Track 5 mechanism —
+`child.asAdmin().strategies.addStrategies(optionsStrategy)` — was
+concurrent-unsafe: `__.start()` aliases the child's `strategies` field to
+the shared `TraversalStrategies.GlobalCache[EmptyGraph]` singleton, so
+`addStrategies` mutated a process-wide container and threw
+`ConcurrentModificationException` under concurrent load. Track 7 revises
+the mechanism (D9) to break the alias before writing — see the dedicated
+"Concurrent safety of UnionAll anonymous-child strategies" section below.
 
 **HasLabel step merging (guarded by optimizer).**
 TinkerPop's `InlineFilterStrategy` merges consecutive `HasStep` objects;
@@ -261,3 +356,306 @@ three points: the O7 double-label guard falls to `Aggregate` when consecutive
 `InlineFilterStrategy` cannot merge it with branch-level steps; and the O19
 `extractCondition` guard avoids producing double-labeled `FollowLink`
 queries.
+
+## Concurrent safety of UnionAll anonymous-child strategies (D9)
+
+`GremlinQuery.UnionAll.subtraversals()` creates anonymous child traversals
+via `__.start<Any>()` for each subquery, then attaches an `OptionsStrategy`
+so that provider strategies (notably `YTDBGraphStepStrategy`) can read
+`polymorphicQuery` during strategy application on the child. The original
+Track 5 mechanism mutated the child's `strategies` container in place via
+`addStrategies(optionsStrategy)`. This is unsafe because TinkerPop aliases
+that container to a **process-wide singleton** shared across every
+anonymous traversal in the JVM.
+
+The revised mechanism (Track 7, D9) replaces the child's `strategies` field
+with a freshly allocated `DefaultTraversalStrategies` containing only the
+`OptionsStrategy`. No shared state is ever written to. The child's
+strategies are read once during strategy application and then overwritten
+by TinkerPop's `lock()` with the parent traversal's strategies, so the
+private container's lifetime is bounded to a single strategy-application
+pass.
+
+### Class interaction
+
+```mermaid
+classDiagram
+    class GremlinQuery_UnionAll {
+        -subqueries: List~GremlinQuery~
+        -subtraversals(optionsStrategy, counter, sortApplied) Pair
+        +startTraversal(gs) YTBuilder
+        +continueTraversal(t, counter, ignoreSort) YTBuilder
+    }
+
+    class TraversalAdmin {
+        <<interface>>
+        +strategies: TraversalStrategies
+        +lock()
+        +applyStrategies()
+    }
+
+    class DefaultGraphTraversal {
+        -strategies: TraversalStrategies
+    }
+
+    class TraversalStrategies {
+        <<interface>>
+        +addStrategies(strategies...) TraversalStrategies
+        +getStrategy(class) Optional
+    }
+
+    class DefaultTraversalStrategies {
+        -traversalStrategies: LinkedHashSet
+        +addStrategies(strategies...) TraversalStrategies
+    }
+
+    class GlobalCache {
+        <<singleton>>
+        -GRAPH_CACHE: Map
+        +getStrategies(class) TraversalStrategies
+    }
+
+    class OptionsStrategy {
+        +options: Map
+    }
+
+    DefaultGraphTraversal ..|> TraversalAdmin
+    DefaultTraversalStrategies ..|> TraversalStrategies
+    GremlinQuery_UnionAll --> DefaultGraphTraversal : creates via __.start()
+    GremlinQuery_UnionAll --> DefaultTraversalStrategies : allocates fresh
+    GremlinQuery_UnionAll --> OptionsStrategy : extracts from parent
+    DefaultGraphTraversal --> DefaultTraversalStrategies : strategies (private)
+    GlobalCache ..> DefaultTraversalStrategies : default aliased (before fix)
+```
+
+The key structural fact is the **indirection** between a freshly created
+anonymous traversal and its strategies container. By default
+`DefaultGraphTraversal()`'s `strategies` field is a *reference* to the
+singleton returned by `GlobalCache.getStrategies(EmptyGraph.class)`. The
+fix breaks this reference before any write happens: the child is given
+its own `DefaultTraversalStrategies` instance, into which the
+`OptionsStrategy` is then added.
+
+### Race on the shared container (old mechanism)
+
+```mermaid
+sequenceDiagram
+    participant T1 as Thread 1
+    participant T2 as Thread 2
+    participant SHARED as GlobalCache[EmptyGraph]<br/>(shared LinkedHashSet)
+    participant SS as sortStrategies
+
+    Note over T1,T2: Both threads evaluate a UnionAll concurrently
+
+    T1->>T1: child1 = __.start()
+    T1->>SHARED: child1.asAdmin().strategies == SHARED (aliased)
+    T1->>SHARED: addStrategies(optionsStrategy_T1)
+    SHARED->>SS: sortStrategies() iterates LinkedHashSet
+
+    T2->>T2: child2 = __.start()
+    T2->>SHARED: child2.asAdmin().strategies == SHARED (aliased)
+    T2->>SHARED: addStrategies(optionsStrategy_T2)
+    SHARED-->>SS: mutation during T1's iteration
+
+    Note over SS: ConcurrentModificationException
+```
+
+Each outer compilation issues `addStrategies` for every subquery and every
+nested `UnionAll` level. Concurrent requests in a web server context
+(observed in YouTrack / youtrackdb-migration) reliably collide on the
+shared `LinkedHashSet`.
+
+### Private container per child (new mechanism)
+
+```mermaid
+sequenceDiagram
+    participant T1 as Thread 1
+    participant T2 as Thread 2
+    participant PRIV1 as T1.child.strategies (fresh)
+    participant PRIV2 as T2.child.strategies (fresh)
+    participant SHARED as GlobalCache[EmptyGraph]
+
+    T1->>T1: child1 = __.start()
+    T1->>T1: admin1.strategies = new DefaultTraversalStrategies()
+    Note over T1,PRIV1: alias to SHARED is broken
+    T1->>PRIV1: addStrategies(optionsStrategy_T1)
+
+    T2->>T2: child2 = __.start()
+    T2->>T2: admin2.strategies = new DefaultTraversalStrategies()
+    Note over T2,PRIV2: alias to SHARED is broken
+    T2->>PRIV2: addStrategies(optionsStrategy_T2)
+
+    Note over PRIV1,PRIV2: No shared state — no race
+```
+
+Each thread allocates its own container before the first write, so there
+is never a window in which two threads touch the same collection.
+
+### Full lifecycle: why "fresh empty + our OptionsStrategy" is sufficient
+
+```mermaid
+sequenceDiagram
+    participant UA as UnionAll.subtraversals
+    participant Child as child traversal
+    participant Root as root traversal
+    participant Strat as YTDBGraphStepStrategy
+    participant Lock as Child.lock()
+
+    UA->>Child: __.start()
+    UA->>Child: admin.strategies = new DefaultTraversalStrategies()
+    UA->>Child: admin.strategies.addStrategies(optionsStrategy)
+    UA->>Child: integrate into parent via union(...)
+
+    Root->>Root: applyStrategies() (iterates root strategies only)
+    Root->>Strat: strategy.apply(root)
+    Strat->>Strat: recurse into children
+    Strat->>Child: apply(child)
+    Child->>Child: getStrategy(OptionsStrategy.class) -> present
+    Strat->>Strat: rebuild step with polymorphic=false
+
+    Root->>Lock: lock()
+    Lock->>Child: setStrategies(parent.getStrategies())
+    Note over Child: private container is now discarded
+```
+
+The critical observation: children's strategies are **only read** during
+strategy application (`Strat.apply(child)` calls `getStrategy(...)`). They
+are **never iterated** on children — `DefaultTraversal.applyStrategies`
+iterates strategies only when `isRoot()` is true (`DefaultTraversal.java:144`).
+After the strategy pass, `lock()` throws away the private container by
+assigning the parent's strategies (`DefaultTraversal.java:338`). So "fresh
+empty with only our `OptionsStrategy`" is sufficient even if the
+`EmptyGraph` global cache would conceptually hold additional strategies —
+none of them would be read from the child anyway.
+
+### Why not `clone()` the shared container
+
+`TraversalStrategies.clone()` produces a new `LinkedHashSet` with the same
+entries as the source (`DefaultTraversalStrategies.java:88–93`). For an
+anonymous traversal, the source is
+`GlobalCache.getStrategies(EmptyGraph.class)`, which TinkerPop initializes
+to an **empty** `DefaultTraversalStrategies` (`TraversalStrategies.java:292`).
+Cloning an empty container yields an empty container. That is correct, but
+it is the same end-state as allocating a fresh `DefaultTraversalStrategies()`.
+The fresh-container approach expresses the intent more directly — "this
+child's strategies are private and initially empty" — and does not imply
+any reliance on whatever happens to live in the global cache at the moment
+of cloning.
+
+### Why not `DefaultGraphTraversal(gs)` (non-anonymous child)
+
+For `startTraversal(gs)`, constructing `DefaultGraphTraversal(gs)` inherits
+`gs.getStrategies()` by reference, which already contains the
+`OptionsStrategy` that the caller set via `.with(polymorphicQuery, …)`.
+This eliminates the need for `addStrategies` on the child. However:
+
+1. **Asymmetry.** `continueTraversal(parent, ...)` has only a parent
+   traversal, not a `GraphTraversalSource`. We would have to either
+   (a) plumb a source through the `continueTraversal` API — an invasive
+   change across every `GremlinQuery` variant — or (b) fall back to
+   `DefaultGraphTraversal(parent.getGraph())`, which would alias
+   `GlobalCache[graph.class]` and reintroduce the same shared-mutation
+   trap.
+2. **Still aliased.** `DefaultTraversal(TraversalSource)` sets
+   `this.strategies = source.getStrategies()` by reference, not by copy.
+   A `GraphTraversalSource` is typically long-lived; mutations would
+   leak back to it. We don't currently mutate, but any future addition
+   of a `child.asAdmin().strategies.addStrategies(…)` call would race.
+
+The chosen approach (fresh private container) has neither drawback: one
+uniform code path, no aliasing of any externally visible container.
+
+### Why not read `OptionsStrategy` from the root (consumer-side)
+
+The architecturally cleanest fix lives on the consumer side: change
+YouTrackDB's `YTDBStrategyUtil.isPolymorphic(traversal)` to walk to the
+root via `TraversalHelper.getRootTraversal(traversal)` and read
+`OptionsStrategy` from the root. This removes child-level strategy
+mutation entirely and would allow `UnionAll.subtraversals` to be a
+completely stateless function that just creates anonymous children.
+
+It is the right long-term direction but out of scope here because it
+requires coordinated changes across xodus-dnq and
+youtrackdb-migration / YouTrackDB core. The fresh-container fix is a
+self-contained, local change that eliminates the race today and does
+not block the cleaner consumer-side refactor later.
+
+### Concurrency invariant
+
+**Invariant:** Any strategies container that `UnionAll.subtraversals`
+writes to must be privately allocated by `UnionAll.subtraversals` itself.
+Stated contra-positively: it must never write to a container obtained
+transitively from `__.start()`, `DefaultGraphTraversal(gs)`,
+`DefaultGraphTraversal(graph)`, or
+`TraversalStrategies.GlobalCache.getStrategies(...)`.
+
+This invariant is enforced structurally by the new code: the child's
+`strategies` field is reassigned to a `new DefaultTraversalStrategies()`
+before any `addStrategies` call. The regression test
+`YTDBPolymorphicQueryTest."UnionAll subtraversals does not mutate shared
+EmptyGraph strategies"` exercises the invariant directly rather than
+reproducing its symptom. It snapshots
+`TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class)` at
+test entry, runs one `union(a, b).count()` on two non-polymorphic label
+queries, and asserts the strategy list is unchanged index-by-index by
+reference identity (`===`). The pre-fix
+`child.asAdmin().strategies.addStrategies(optionsStrategy)` call would
+either insert a new `OptionsStrategy` into the shared set (when the
+cache starts clean) or replace a same-class incumbent (since
+`addStrategies` removes any same-class entry first); identity-wise
+comparison catches both deterministically, single-threaded, without
+needing the race to reproduce. Class equality alone —
+`AbstractTraversalStrategy.equals` compares by class — would hide the
+replacement case if a prior test in the same JVM fork has already
+polluted the cache. This also gates against regressions that fix the
+CME but reinstate shared-cache mutation (e.g. a hypothetical
+`synchronized { sharedStrategies.addStrategies(…) }`).
+
+### Gotchas
+
+- **Silent fallback.** If the fresh container is ever accidentally
+  allocated but never populated with the `OptionsStrategy`,
+  `YTDBStrategyUtil.isPolymorphic` falls back to
+  `GlobalConfiguration.QUERY_GREMLIN_POLYMORPHIC_BY_DEFAULT`. A
+  non-polymorphic outer query with a `.concat`-like child would silently
+  become polymorphic. The code guards this with an
+  `if (optionsStrategy != null)` around the whole replace+add block,
+  which means "no options to propagate" and "don't touch the child's
+  strategies" are the same case. Future modifications must preserve
+  this: either (a) always replace the strategies container *and*
+  populate it, or (b) skip both.
+- **TinkerPop version coupling.** The correctness argument depends on
+  three TinkerPop implementation facts that might change between
+  versions: `DefaultTraversal()` aliasing `GlobalCache[EmptyGraph.class]`,
+  `applyStrategies` iterating only on root, and `lock()` overwriting
+  child strategies with the parent's. Any TinkerPop (or
+  youtrackdb-core) upgrade must re-verify each item on the **D9
+  upgrade checklist** in `adr.md` (D9 Risks/Caveats). If any fact
+  changes, the `UnionAll.subtraversals` correctness argument must be
+  re-evaluated — the consumer-side root-lookup fix in YouTrackDB
+  (D9 Alternative 3) is the natural next step and is the recommended
+  long-term direction regardless.
+
+### Other anonymous-traversal sites
+
+Track 7's D9 fix targets `UnionAll.subtraversals()` specifically. The
+codebase contains other sites that construct anonymous traversals via
+`__.start()` but do **not** currently propagate `OptionsStrategy` —
+they are not polymorphism-aware today, so the Track 5/7 race is not
+reproducible through them:
+
+- `GremlinQuery.AggregateNoOrder.startTraversal` / `.continueTraversal`
+  (in `GremlinQuery.kt`). Emits anonymous traversals for the aggregate
+  branches; `polymorphicQuery` never reaches them today.
+- `GremlinBlock.Or`, `.And`, `.Where`, `.Not` inner predicates. These
+  build anonymous sub-predicates for Gremlin step-level filtering;
+  again, `polymorphicQuery` is not propagated into them today.
+
+These sites are out of scope for Track 7 (user decision) and are
+recorded here purely as a forward-compatibility note. **Any future
+change that adds `OptionsStrategy` propagation to these sites MUST
+follow the D9 private-container rule** — allocate a fresh
+`DefaultTraversalStrategies`, assign it to the child's `strategies`
+field *before* any `addStrategies` call, and keep the "replace iff
+populate" invariant. Mutating the child's default strategies in place
+would reintroduce the D5 race.


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                             
Extends the non-polymorphic query support added in XD-1266 so the `polymorphic` flag is honored consistently across the full query tree evaluation path, not just at the top-level iterable. 

To fix code like this one:

```kotlin
val result = User.all(polymorphic = false)
              .filter { it.skill gt 0 }
              .filter { it.skill gt 3 }
              .toList()     
```                                                                                                                                                                
                                                                                                                                                                                                             
## Changes
                                                                                                                                                                                                             
**Propagate `polymorphic` through `NodeBase.instantiate`**
- `NodeBase.instantiate` gains a `polymorphic` parameter (overload keeps the old 3-arg signature as a `true` default for compatibility).
- `LeafNode`, `UnaryNode`, and `BinaryNode` forward the flag to `YTDBEntityIterable.query`, so `hasLabel(type)` filters are emitted with the correct polymorphism.
- `QueryEngine.query` reads `polymorphic` from the unwrapped input iterable and passes it down, fixing a mismatch where the root iterable was non-polymorphic but the tree-built intersection was polymorphic.

**Fix `XdQuery.filterNotNull`**
- Now forwards `this.polymorphic` when constructing the filter iterable so `filterNotNull` on a non-polymorphic query stays non-polymorphic.

**Fix `ConcurrentModificationException` in `UnionAll` subtraversals**
- `__.start()` aliases its strategies field to the shared `TraversalStrategies.GlobalCache[EmptyGraph]` singleton. Calling `addStrategies(optionsStrategy)` on this shared `LinkedHashSet` from multiple threads caused `ConcurrentModificationException` in `sortStrategies` and leaked options globally.
- Fixed by replacing the child's strategies container with a fresh `DefaultTraversalStrategies` instance before adding `OptionsStrategy`, so each subtraversal gets a private container that doesn't race or pollute the global cache.

## Tests
                  
- New `YTDBPolymorphicQueryTest` covers the iterable-level propagation paths.
- `XdEntityTypePolymorphicTest` extended with concrete-type scenarios and cases exercising `ByIds` ↔ label-based iterable combinations.
- `UnionAll subtraversals does not mutate shared EmptyGraph strategies` — asserts the `GlobalCache[EmptyGraph]` invariant deterministically (snapshot compared by identity, not equality).