### PR TITLE
JT-95690 Fix UnsupportedOperationException when querying TransientEntityIterable

### DIFF
--- a/dnq-entity-store/build.gradle.kts
+++ b/dnq-entity-store/build.gradle.kts
@@ -1,4 +1,4 @@
-val ytdbVersion = "0.5.0-20260419.105410-6a4b5d7-SNAPSHOT"
+val ytdbVersion = "0.5.0-20260428.132449-152"
 
 val ktorVersion = "3.1.3"
 val graalVmVersion = "22.0.0.2"

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
@@ -57,7 +57,7 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
         return when {
             modelMetaData != null && modelMetaData.getEntityMetaData(entityType) == null -> YTDBEntityIterable.EMPTY
             instance == null -> tree.instantiate(entityType, this, modelMetaData) as EntityIterable
-            instance is EntityIterable -> {
+            instance is EntityIterable && instance.isPersistent -> {
                 if (tree is LeafNode && tree.query is GremlinQuery.SortBy) {
                     val sorted = applySort(tree, entityType, instance)
                     sorted as? EntityIterable ?: InMemoryEntityIterable(sorted, txn = persistentStore.andCheckCurrentTransaction, this)
@@ -159,20 +159,18 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
     }
 
     private fun canAggregate(left: Iterable<Entity>, right: Iterable<Entity>): Boolean =
-        if (left.isPersistent) right.isPersistent
-        else left is EntityIterable && right is EntityIterable
+        left.isPersistent && right.isPersistent
 
     open fun selectDistinct(it: Iterable<Entity>?, linkName: String): Iterable<Entity> {
-        return if (it is EntityIterable) {
+        return if (it is EntityIterable && it.isPersistent) {
             it.selectDistinct(linkName)
         } else {
             it?.let { inMemorySelectDistinct(it, linkName) } ?: YTDBEntityIterable.EMPTY
         }
-
     }
 
     open fun selectManyDistinct(it: Iterable<Entity>?, linkName: String): Iterable<Entity> {
-        return if (it is EntityIterable) {
+        return if (it is EntityIterable && it.isPersistent) {
             it.selectManyDistinct(linkName)
         } else {
             it?.let { inMemorySelectManyDistinct(it, linkName) } ?: YTDBEntityIterable.EMPTY

--- a/dnq/src/test/kotlin/kotlinx/dnq/events/ListenersTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/events/ListenersTest.kt
@@ -16,19 +16,20 @@
 package kotlinx.dnq.events
 
 import com.google.common.truth.Truth
-import jetbrains.exodus.database.RemovedEntityData
 import jetbrains.exodus.entitystore.EntityId
 import kotlinx.dnq.DBTest
 import kotlinx.dnq.XdModel
 import kotlinx.dnq.listener.XdEntityListener
 import kotlinx.dnq.listener.addListener
 import kotlinx.dnq.query.asSequence
+import kotlinx.dnq.query.filter
 import kotlinx.dnq.query.size
 import kotlinx.dnq.query.toList
+import kotlinx.dnq.util.getAddedLinks
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.Ignore
+import java.util.concurrent.atomic.AtomicReference
 
 class ListenersTest : DBTest() {
 
@@ -252,6 +253,46 @@ class ListenersTest : DBTest() {
         }
         Assert.assertEquals(0, refNew.get())
         Assert.assertEquals(2, refOld.get())
+    }
+
+    /**
+     * Reproducer: filtering added links inside an updatedSync listener crashes with
+     * UnsupportedOperationException because TransientEntityIterable.intersect() is not supported.
+     *
+     * getAddedLinks() returns a TransientEntityIterable wrapped in XdQuery.
+     * Calling .filter {} invokes QueryEngine.query(instance=TransientEntityIterable, ...),
+     * which enters the `instance is EntityIterable` branch and calls instance.intersect() — crash.
+     */
+    @Test
+    fun `filter added links in updatedSync listener should not crash`() {
+        val g = store.transactional {
+            Goo.new()
+        }
+        val result = AtomicReference<List<Int>>()
+        val error = AtomicReference<Throwable>()
+        Goo.addListener(store, object : XdEntityListener<Goo> {
+            override fun updatedSync(old: Goo, current: Goo) {
+                try {
+                    val filtered = old.getAddedLinks(Goo::content)
+                        .filter { it.intField eq 2 }
+                        .toList()
+                    result.set(filtered.map { it.intField })
+                } catch (e: Throwable) {
+                    error.set(e)
+                }
+            }
+        })
+        store.transactional {
+            g.content.add(Foo.new { intField = 1 })
+            g.content.add(Foo.new { intField = 2 })
+            g.content.add(Foo.new { intField = 3 })
+        }
+        if (error.get() != null) {
+            throw AssertionError(
+                "Filtering TransientEntityIterable should not crash", error.get()
+            )
+        }
+        Truth.assertThat(result.get()).containsExactly(2)
     }
 
     @Test

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/TransientEntityIterableSetOpsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/TransientEntityIterableSetOpsTest.kt
@@ -1,0 +1,225 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq.query
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.dnq.DBTest
+import kotlinx.dnq.XdModel
+import kotlinx.dnq.events.Foo
+import kotlinx.dnq.events.Goo
+import kotlinx.dnq.listener.XdEntityListener
+import kotlinx.dnq.listener.addListener
+import kotlinx.dnq.util.getAddedLinks
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Tests that QueryEngine set operations (query/filter, intersect, union, exclude,
+ * selectDistinct, selectManyDistinct) work correctly when one operand is a
+ * TransientEntityIterable.
+ *
+ * TransientEntityIterable implements EntityIterable but throws UnsupportedOperationException
+ * on intersect/union/minus/selectDistinct/selectManyDistinct. The QueryEngine must detect
+ * non-persistent EntityIterables and fall back to in-memory implementations.
+ */
+class TransientEntityIterableSetOpsTest : DBTest() {
+
+    override fun registerEntityTypes() {
+        super.registerEntityTypes()
+        XdModel.registerNodes(Foo, Goo)
+    }
+
+    /**
+     * Helper: runs a block inside a Goo updatedSync listener where getAddedLinks(Goo::content)
+     * produces a TransientEntityIterable-backed XdQuery<Foo>.
+     *
+     * Returns the result of [block] or throws if the listener threw.
+     */
+    private fun <T> withAddedFooLinks(
+        fooCount: Int = 3,
+        block: (addedLinks: XdQuery<Foo>) -> T
+    ): T {
+        val g = store.transactional { Goo.new() }
+        val result = AtomicReference<T>()
+        val error = AtomicReference<Throwable>()
+        Goo.addListener(store, object : XdEntityListener<Goo> {
+            override fun updatedSync(old: Goo, current: Goo) {
+                try {
+                    result.set(block(old.getAddedLinks(Goo::content)))
+                } catch (e: Throwable) {
+                    error.set(e)
+                }
+            }
+        })
+        store.transactional {
+            repeat(fooCount) { i ->
+                g.content.add(Foo.new { intField = i + 1 })
+            }
+        }
+        error.get()?.let { throw AssertionError("Listener should not crash", it) }
+        return result.get()
+    }
+
+    // --- QueryEngine.query path (filter) ---
+
+    @Test
+    fun `filter TransientEntityIterable`() {
+        val values = withAddedFooLinks {
+            it.filter { f -> f.intField eq 2 }.toList().map { f -> f.intField }
+        }
+        assertThat(values).containsExactly(2)
+    }
+
+    // --- canAggregate path: intersect, union, exclude ---
+
+    @Test
+    fun `intersect TransientEntityIterable with persistent query`() {
+        val values = withAddedFooLinks {
+            it.intersect(Foo.all()).toList().map { f -> f.intField }
+        }
+        assertThat(values).containsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun `union TransientEntityIterable with persistent query`() {
+        // pre-create a Foo that won't be in the added links
+        store.transactional { Foo.new { intField = 99 } }
+        val g = store.transactional { Goo.new() }
+        val result = AtomicReference<List<Int>>()
+        val error = AtomicReference<Throwable>()
+        Goo.addListener(store, object : XdEntityListener<Goo> {
+            override fun updatedSync(old: Goo, current: Goo) {
+                try {
+                    val added = old.getAddedLinks(Goo::content)
+                    val unionResult = added.union(Foo.all()).toList().map { it.intField }
+                    result.set(unionResult)
+                } catch (e: Throwable) {
+                    error.set(e)
+                }
+            }
+        })
+        store.transactional {
+            g.content.add(Foo.new { intField = 1 })
+        }
+        error.get()?.let { throw AssertionError("Listener should not crash", it) }
+        assertThat(result.get()).containsExactly(1, 99)
+    }
+
+    @Test
+    fun `exclude persistent query from TransientEntityIterable`() {
+        // pre-create a Foo that will also be added to Goo
+        val existing = store.transactional { Foo.new { intField = 99 } }
+        val g = store.transactional { Goo.new() }
+        val result = AtomicReference<List<Int>>()
+        val error = AtomicReference<Throwable>()
+        Goo.addListener(store, object : XdEntityListener<Goo> {
+            override fun updatedSync(old: Goo, current: Goo) {
+                try {
+                    val added = old.getAddedLinks(Goo::content)
+                    // Query that matches only intField==99
+                    val toExclude = Foo.all().filter { it.intField eq 99 }
+                    // addedLinks(1,2,99) \ toExclude(99) should keep 1 and 2
+                    // TransientEntityIterable is on the LEFT — this is the crashing path
+                    val excludeResult = added.exclude(toExclude).toList().map { it.intField }
+                    result.set(excludeResult)
+                } catch (e: Throwable) {
+                    error.set(e)
+                }
+            }
+        })
+        store.transactional {
+            g.content.add(Foo.new { intField = 1 })
+            g.content.add(Foo.new { intField = 2 })
+            g.content.add(existing)
+        }
+        error.get()?.let { throw AssertionError("Listener should not crash", it) }
+        assertThat(result.get()).containsExactly(1, 2)
+    }
+
+    // --- selectDistinct / selectManyDistinct path ---
+
+    @Test
+    fun `mapDistinct on TransientEntityIterable`() {
+        // Setup: RootGroup links to Users, User has supervisor (0_1 link)
+        val (_, worker1, worker2) = store.transactional {
+            val boss = User.new { login = "boss"; skill = 1 }
+            val w1 = User.new { login = "w1"; skill = 1; supervisor = boss }
+            val w2 = User.new { login = "w2"; skill = 1; supervisor = boss }
+            Triple(boss, w1, w2)
+        }
+        val group = store.transactional { RootGroup.new { name = "g1" } }
+        val result = AtomicReference<List<String>>()
+        val error = AtomicReference<Throwable>()
+        RootGroup.addListener(store, object : XdEntityListener<RootGroup> {
+            override fun updatedSync(old: RootGroup, current: RootGroup) {
+                try {
+                    val addedUsers = old.getAddedLinks(RootGroup::users)
+                    // mapDistinct(supervisor) calls queryEngine.selectDistinct()
+                    val supervisors = addedUsers
+                        .mapDistinct(User::supervisor)
+                        .toList()
+                        .map { it.login }
+                    result.set(supervisors)
+                } catch (e: Throwable) {
+                    error.set(e)
+                }
+            }
+        })
+        store.transactional {
+            group.users.add(worker1)
+            group.users.add(worker2)
+        }
+        error.get()?.let { throw AssertionError("Listener should not crash", it) }
+        assertThat(result.get()).containsExactly("boss")
+    }
+
+    @Test
+    fun `flatMapDistinct on TransientEntityIterable`() {
+        // Setup: RootGroup links to Users, User has contacts (0_N link)
+        val (user1, user2) = store.transactional {
+            val u1 = User.new { login = "u1"; skill = 1 }
+            Contact.new { user = u1; email = "a@test.com" }
+            Contact.new { user = u1; email = "b@test.com" }
+            val u2 = User.new { login = "u2"; skill = 1 }
+            Contact.new { user = u2; email = "c@test.com" }
+            Pair(u1, u2)
+        }
+        val group = store.transactional { RootGroup.new { name = "g2" } }
+        val result = AtomicReference<List<String>>()
+        val error = AtomicReference<Throwable>()
+        RootGroup.addListener(store, object : XdEntityListener<RootGroup> {
+            override fun updatedSync(old: RootGroup, current: RootGroup) {
+                try {
+                    val addedUsers = old.getAddedLinks(RootGroup::users)
+                    // flatMapDistinct(contacts) calls queryEngine.selectManyDistinct()
+                    val emails = addedUsers
+                        .flatMapDistinct(User::contacts)
+                        .toList()
+                        .map { it.email }
+                    result.set(emails)
+                } catch (e: Throwable) {
+                    error.set(e)
+                }
+            }
+        })
+        store.transactional {
+            group.users.add(user1)
+            group.users.add(user2)
+        }
+        error.get()?.let { throw AssertionError("Listener should not crash", it) }
+        assertThat(result.get()).containsExactly("a@test.com", "b@test.com", "c@test.com")
+    }
+}


### PR DESCRIPTION
`TransientEntityIterable` implements `EntityIterable` but throws `UnsupportedOperationException` on set operations (`intersect`, `union`, `minus`, `selectDistinct`, `selectManyDistinct`). 

`QueryEngine` checked is `EntityIterable` to decide whether to call native operations, which route `TransientEntityIterable` into code paths that crash.
 
 The fix consistently uses the existing `isPersistent` predicate — which checks that an `EntityIterable` unwraps to a `YTDBEntityIterable` — at all decision points in `QueryEngine`:
  - `query()`: tighten when-condition to instance is `EntityIterable && instance.isPersistent`
  - `canAggregate()`: simplify to `left.isPersistent && right.isPersistent`
  - `selectDistinct()/selectManyDistinct()`: add `isPersistent` guard Non-persistent EntityIterables now fall through to in-memory implementations which handle them correctly.