### PR TITLE
Fix ReadonlyTransientEntity.getLink for snapshots read after flush

### DIFF
--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadonlyTransientEntity.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadonlyTransientEntity.kt
@@ -94,9 +94,17 @@ class ReadonlyTransientEntity(change: TransientEntityChange?, snapshot: YTDBEnti
     }
     //endregion
 
-    override fun getLink(linkName: String): Entity? =
-        originalValuesProvider.getOriginalLinkValue(this, linkName)
-            ?.let { SnapshotEntityIterator.wrapEntity(it, store) }
+    override fun getLink(linkName: String): Entity? {
+        val change = changedLinks[linkName]
+        if (change != null) {
+            change.removedEntities?.firstOrNull()
+                ?.let { return SnapshotEntityIterator.wrapEntity(it, store) }
+            change.deletedEntitiesSnapshots?.firstOrNull()
+                ?.let { return it }
+            return null
+        }
+        return entity.getLink(linkName)?.let { SnapshotEntityIterator.wrapEntity(it, store) }
+    }
 
     override fun getLink(linkName: String, session: TransientStoreSession?): Entity? {
         return getLink(linkName)

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/RemovedTransientEntity.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/RemovedTransientEntity.kt
@@ -94,7 +94,7 @@ open class RemovedTransientEntity(
     }
 
     override fun getPropertyOldValue(propertyName: String): Comparable<*>? {
-        throw IllegalStateException("Entity is removed")
+        return getProperty(propertyName)
     }
 
     override fun setToOne(linkName: String, target: Entity?) {

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
@@ -71,7 +71,7 @@ internal class SnapshotEntityIterable(
 
     override fun asSortResult(): EntityIterable = wrap(original.asSortResult())
 
-    override fun unwrap(): EntityIterable = wrap(original.unwrap())
+    override fun unwrap(): EntityIterable = original.unwrap()
 
     override fun findLinks(entities: EntityIterable, linkName: String): EntityIterable =
         wrap(original.findLinks(entities, linkName))

--- a/dnq/src/test/kotlin/kotlinx/dnq/RemovedTransientEntityTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/RemovedTransientEntityTest.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import com.jetbrains.teamsys.dnq.database.threadSessionOrThrow
+import jetbrains.exodus.database.TransientEntity
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RemovedTransientEntityTest : DBTest() {
+
+    @Test
+    fun `getPropertyOldValue on snapshot of removed entity returns pre-removal value`() {
+        val user = store.transactional {
+            User.new {
+                login = "alice"
+                skill = 1
+            }
+        }
+
+        store.transactional {
+            val transientEntity = user.entity as TransientEntity
+            user.delete()
+            val snapshot = transientEntity.store.threadSessionOrThrow
+                .transientChangesTracker
+                .getSnapshotEntity(transientEntity)
+            assertTrue(snapshot.isRemoved)
+            assertEquals("alice", snapshot.getPropertyOldValue("login"))
+        }
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransientStoreSessionListenerTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransientStoreSessionListenerTest.kt
@@ -408,6 +408,67 @@ class TransientStoreSessionListenerTest : DBTest() {
         listOf(t1, t2).forEach { it.join() }
         listener.check(count = 2)
     }
+
+    @Test
+    fun `snapshot entity in flushed listener should return old link value for changed to-one link`() {
+        val parent1 = store.transactional { LevelOneEntity.new { name = "parent1" } }
+        val parent2 = store.transactional { LevelOneEntity.new { name = "parent2" } }
+        val child = store.transactional { LevelTwoEntity.new { name = "child"; parent = parent1 } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.UPDATE && it.transientEntity.id == child.entityId
+            } ?: error("expected UPDATE change for child")
+            // Snapshot must reflect state before the transaction: parent should still be parent1
+            assertEquals(parent1.entityId, childChange.snapshotEntity.getLink("parent")?.id)
+        }
+
+        store.transactional { child.parent = parent2 }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot entity in flushed listener should return old link value for cleared to-one link`() {
+        val parent1 = store.transactional { LevelOneEntity.new { name = "parent1" } }
+        val child = store.transactional { LevelTwoEntity.new { name = "child"; parent = parent1 } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.UPDATE && it.transientEntity.id == child.entityId
+            } ?: error("expected UPDATE change for child")
+            // Link was cleared to null; snapshot must still see the original parent1
+            assertEquals(parent1.entityId, childChange.snapshotEntity.getLink("parent")?.id)
+        }
+
+        store.transactional { child.parent = null }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot entity in flushed listener should return null for to-one link set from null`() {
+        val parent1 = store.transactional { LevelOneEntity.new { name = "parent1" } }
+        val child = store.transactional { LevelTwoEntity.new { name = "child" } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.UPDATE && it.transientEntity.id == child.entityId
+            } ?: error("expected UPDATE change for child")
+            // Link was set from null; snapshot must report the original null value
+            assertEquals(null, childChange.snapshotEntity.getLink("parent"))
+        }
+
+        store.transactional { child.parent = parent1 }
+        listener.check()
+    }
 }
 
 class CallbackListener : TransientStoreSessionListener {


### PR DESCRIPTION
`ReadonlyTransientEntity.getLink` delegated to `TransientEntityOriginalValuesProviderImpl`, which queries `session.transientChangesTracker`. 
After flush, the tracker is replaced with `ReadOnlyTransientChangesTrackerImpl` whose `getChangedLinksDetailed` returns `emptyMap()`, so the original lookup falls through to `entity.getLink` and returns the post-flush value. 
Read the original from the captured `LinkChange` (`removedEntities` / `deletedEntitiesSnapshots`), matching how `getProperty` and `getLinks` already handle the same problem.

Add listener tests covering all to-one `LinkChange` shapes (`ADD_AND_REMOVE`, `REMOVE`, `ADD`) in the flushed callback path.

Also unwrap `SnapshotEntityIterable.unwrap()` to the underlying iterable instead of re-wrapping.
