### PR TITLE
Fix YTDB-migration regressions in delete listeners and snapshots

### DIFF
--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/SortEngine.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/SortEngine.kt
@@ -68,6 +68,14 @@ open class SortEngine {
         source: Iterable<Entity>,
         asc: Boolean
     ): Iterable<Entity> {
+        // Short-circuit empty sources before touching source.query — YTDBEntityIterable.EMPTY's
+        // query stub throws "Should never be called" (mirrors the empty guard in the property sort above).
+        if ((source as? EntityIterable)?.unwrap() === YTDBEntityIterable.EMPTY) {
+            return YTDBEntityIterable.EMPTY
+        }
+        if (source !is EntityIterable && source.none()) {
+            return YTDBEntityIterable.EMPTY
+        }
         // todo: validate this logic
         if (source is YTDBEntityIterable && source.query !is GremlinQuery.ByIds) {
             val txn = queryEngine.persistentStore.andCheckCurrentTransaction

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityOperations.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/EntityOperations.kt
@@ -38,11 +38,14 @@ object EntityOperations {
     @JvmStatic
     internal fun remove(e: Entity?, callDestructorPhase: Boolean, processed: MutableSet<Entity>) {
         if (callDestructorPhase) {
-            // calling "before removed" to create links snapshot
-            (e as? TransientEntity)
-                ?.threadSessionOrThrow
-                ?.transientChangesTracker
-                ?.entityBeforeRemoved(e)
+            // calling "before removed" to create links snapshot.
+            // Upgrade the read-only tracker first (post-flush state) so the snapshot
+            // is captured by the writable tracker — otherwise the call lands on the
+            // read-only no-op/throw and the pre-removal link state is lost before
+            // Phase 2 strips edges at the storage layer.
+            val session = (e as? TransientEntity)?.threadSessionOrThrow as? TransientSessionImpl
+            session?.upgradeReadonlyTransactionIfNecessary()
+            session?.transientChangesTracker?.entityBeforeRemoved(e)
         }
 
         if (e == null || (e as TransientEntity).isRemoved) return

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadOnlyTransientChangesTrackerImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadOnlyTransientChangesTrackerImpl.kt
@@ -86,6 +86,7 @@ class ReadOnlyTransientChangesTrackerImpl : TransientChangesTracker {
             throw UnsupportedOperationException()
 
     override fun entityBeforeRemoved(e: TransientEntity) {
+        throw UnsupportedOperationException()
     }
 
     override fun entityRemoved(e: TransientEntity): Unit =

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientChangesTrackerImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientChangesTrackerImpl.kt
@@ -277,7 +277,8 @@ class TransientChangesTrackerImpl : TransientChangesTracker {
             ytdbEntity.id as RIDEntityId, ytdbEntity,
             ytdbEntity.store,
             e.store.queryEngine,
-            this
+            this,
+            e,
         )
         return removed
     }

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/YTDBVertexEntityRemoved.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/YTDBVertexEntityRemoved.kt
@@ -15,6 +15,7 @@
  */
 package com.jetbrains.teamsys.dnq.database
 
+import jetbrains.exodus.database.TransientEntity
 import jetbrains.exodus.entitystore.Entity
 import jetbrains.exodus.entitystore.EntityId
 import jetbrains.exodus.entitystore.EntityIterable
@@ -31,7 +32,8 @@ class YTDBVertexEntityRemoved(
     originalVertex: YTDBVertexEntity,
     store: YTDBEntityStore,
     private val queryEngine: QueryEngine,
-    private val changesTracker: TransientChangesTrackerImpl
+    private val changesTracker: TransientChangesTrackerImpl,
+    sourceEntity: TransientEntity,
 ) : YTDBVertexEntity(
     oEntityId = oEntityId,
     ytdbVertex =
@@ -43,12 +45,24 @@ class YTDBVertexEntityRemoved(
     private val links = mutableMapOf<String, Set<EntityId>>()
 
     init {
-        for (link in originalVertex.linkNames) {
-            links[link] = originalVertex
-                .getLinks(link)
-                .asSequence()
-                .map { it.id }
-                .toSet()
+        // The live vertex reflects post-mutation state at delete() time. To get the
+        // pre-transaction state, overlay the tracker's LinkChange records:
+        //   + add back removedEntities / deletedEntities (stripped earlier in txn)
+        //   - subtract addedEntities (added earlier in txn — not in pre-txn state)
+        val linkChanges = changesTracker.getChangedLinksDetailed(sourceEntity).orEmpty()
+        val linkNames = LinkedHashSet<String>(originalVertex.linkNames).apply {
+            addAll(linkChanges.keys)
+        }
+        for (linkName in linkNames) {
+            val ids = originalVertex.getLinks(linkName).asSequence().mapTo(LinkedHashSet()) { it.id }
+            linkChanges[linkName]?.let { change ->
+                change.removedEntities?.forEach { ids.add(it.id) }
+                change.deletedEntities?.forEach { ids.add(it.id) }
+                change.addedEntities?.forEach { ids.remove(it.id) }
+            }
+            if (ids.isNotEmpty()) {
+                links[linkName] = ids
+            }
         }
     }
 

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/TransientEntityUtil.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/TransientEntityUtil.kt
@@ -95,13 +95,11 @@ fun XdEntity.getRemovedLinks(linkName: String): EntityIterable {
 
 fun XdEntity.getOldLinkValue(linkName: String): TransientEntity? {
     val entity = this.entity as TransientEntity
-    val transientStore = entity.store
-    val session = transientStore.threadSessionOrThrow
+    val session = entity.store.threadSessionOrThrow
     return if (session.isRemoved(entity)) {
-        (transientStore.persistentStore as PersistentEntityStore)
-            .getEntity(entity.id)
-            .getLink(linkName)
-            ?.let { session.newEntity(it) }
+        val snapshot = if (entity.isWrapper) entity
+        else session.transientChangesTracker.getSnapshotEntity(entity)
+        snapshot.getLink(linkName)?.let { session.newEntity(it) }
     } else if (entity.isNew) {
         null
     } else if (!entity.hasChanges(linkName)) {

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransientStoreSessionListenerTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransientStoreSessionListenerTest.kt
@@ -15,6 +15,7 @@
  */
 package kotlinx.dnq
 
+import com.jetbrains.teamsys.dnq.association.AggregationAssociationSemantics
 import jetbrains.exodus.database.*
 import jetbrains.exodus.database.exceptions.DataIntegrityViolationException
 import jetbrains.exodus.entitystore.Entity
@@ -467,6 +468,131 @@ class TransientStoreSessionListenerTest : DBTest() {
         }
 
         store.transactional { child.parent = parent1 }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot of removed entity should preserve parent link cleared before delete`() {
+        // A parent link cleared via setManyToOne(null, ...) before delete() in the
+        // same transaction must still resolve to the original parent on the snapshot
+        // of the removed entity. The removal snapshot used to capture link state
+        // live at delete() time — after the in-txn mutation had already stripped
+        // the edge — so a removedSyncBeforeConstraints listener observed null.
+        val parent = store.transactional { ParentEntity.new { name = "p" } }
+        val child = store.transactional { ChildEntity.new { name = "c"; this.parent = parent } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.REMOVE && it.transientEntity.id == child.entityId
+            } ?: error("expected REMOVE change for child")
+            // Snapshot must still see the original parent even though the parent link
+            // was cleared before delete() in the same transaction.
+            assertEquals(parent.entityId, childChange.snapshotEntity.getLink("parent")?.id)
+        }
+
+        store.transactional {
+            AggregationAssociationSemantics.setManyToOne(
+                /* parent = */ null,
+                /* parentToChildLinkName = */ "child",
+                /* childToParentLinkName = */ "parent",
+                /* child = */ child.entity,
+            )
+            child.delete()
+        }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot of removed entity should preserve to-many link cleared before delete`() {
+        // Same regression as the to-one case, exercised on the plural snapshot reader.
+        // A to-many link cleared in the same transaction as delete() must still report
+        // its original members on snapshot.getLinks().
+        val (parent, originalChildren) = store.transactional {
+            val three = LevelThreeEntity.new { name = "three" }
+            val twoA = LevelTwoEntity.new { name = "twoA" }
+            val twoB = LevelTwoEntity.new { name = "twoB" }
+            three.children.add(twoA)
+            three.children.add(twoB)
+            Pair(three, setOf(twoA.entityId, twoB.entityId))
+        }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val parentChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.REMOVE && it.transientEntity.id == parent.entityId
+            } ?: error("expected REMOVE change for parent")
+            val snapshotIds = parentChange.snapshotEntity.getLinks("children").map { it.id }.toSet()
+            assertEquals(originalChildren, snapshotIds)
+        }
+
+        store.transactional {
+            parent.children.clear()
+            parent.delete()
+        }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot of removed entity should reflect to-many link mixed add and remove before delete`() {
+        // Pre-txn children: {A, B}. In the same txn we add C and remove A, then delete
+        // the parent. The snapshot must roll back BOTH mutations: include A (was
+        // removed in-txn) and exclude C (was added in-txn) — yielding the original {A, B}.
+        val (parent, original, added) = store.transactional {
+            val three = LevelThreeEntity.new { name = "three" }
+            val twoA = LevelTwoEntity.new { name = "twoA" }
+            val twoB = LevelTwoEntity.new { name = "twoB" }
+            val twoC = LevelTwoEntity.new { name = "twoC" }
+            three.children.add(twoA)
+            three.children.add(twoB)
+            Triple(three, setOf(twoA.entityId, twoB.entityId), twoC)
+        }
+        val originalA = store.transactional { parent.children.toList().first { it.name == "twoA" } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val parentChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.REMOVE && it.transientEntity.id == parent.entityId
+            } ?: error("expected REMOVE change for parent")
+            val snapshotIds = parentChange.snapshotEntity.getLinks("children").map { it.id }.toSet()
+            assertEquals(original, snapshotIds)
+        }
+
+        store.transactional {
+            parent.children.add(added)
+            parent.children.remove(originalA)
+            parent.delete()
+        }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot of removed entity should exclude to-one link added in same transaction`() {
+        // Pre-txn the child has no parent. In the same txn we set parent and then
+        // delete the child. The snapshot must reflect the pre-txn null — the link
+        // edge added in-txn must be subtracted from the snapshot's link state.
+        val child = store.transactional { LevelTwoEntity.new { name = "orphan" } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.REMOVE && it.transientEntity.id == child.entityId
+            } ?: error("expected REMOVE change for child")
+            assertEquals(null, childChange.snapshotEntity.getLink("parent"))
+        }
+
+        store.transactional {
+            child.parent = LevelOneEntity.new { name = "newParent" }
+            child.delete()
+        }
         listener.check()
     }
 }

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteAfterIntermediateFlushTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/DeleteAfterIntermediateFlushTest.kt
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq.delete
+
+import kotlinx.dnq.DBTest
+import kotlinx.dnq.XdModel
+import kotlinx.dnq.listener.XdEntityListener
+import kotlinx.dnq.listener.addListener
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Parent link must remain accessible in removedSyncBeforeConstraints
+ * when delete() follows an intermediate flush() with pending changes in the
+ * same transaction.
+ */
+class DeleteAfterIntermediateFlushTest : DBTest() {
+
+    override fun registerEntityTypes() {
+        XdModel.registerNodes(Team, Fellow)
+    }
+
+    @Test
+    fun `parent link is accessible in removedSyncBeforeConstraints after intermediate flush`() {
+        val fellow = store.transactional {
+            val team = Team.new { name = "team" }
+            Fellow.new { name = "fellow"; this.team = team }
+        }
+
+        var capturedParent: Team? = null
+        store.changesMultiplexer!!.addListener(Fellow, object : XdEntityListener<Fellow> {
+            override fun removedSyncBeforeConstraints(removed: Fellow) {
+                capturedParent = removed.team
+            }
+        })
+
+        store.transactional { txn ->
+            fellow.name = "updated"
+            txn.flush()
+            fellow.delete()
+        }
+
+        assertNotNull(capturedParent)
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/delete/OldValueTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/delete/OldValueTest.kt
@@ -22,6 +22,8 @@ import com.jetbrains.teamsys.dnq.database.reattachTransient
 import jetbrains.exodus.entitystore.EntityRemovedInDatabaseException
 import kotlinx.dnq.DBTest
 import kotlinx.dnq.XdModel
+import kotlinx.dnq.listener.XdEntityListener
+import kotlinx.dnq.listener.addListener
 import kotlinx.dnq.util.getDBName
 import kotlinx.dnq.util.getOldValue
 import org.junit.Test
@@ -97,5 +99,57 @@ class OldValueTest : DBTest() {
 
             }
         }
+    }
+
+    /**
+     * Counterpart to [oldValueOnDelete]: inside a `removedSync` listener the snapshot
+     * is in hand, so `getOldValue` must succeed even after the entity row is physically
+     * gone from YTDB post-flush.
+     */
+        @Test
+    fun oldLinkValueOnNonSnapshotReferenceAfterDelete() {
+        val (user, role) = store.transactional {
+            val role = RRole.new()
+            val user = RUser.new(name).apply { this.role = role }
+            Pair(user, role)
+        }
+        store.transactional {
+            user.delete()
+            assertThat(user.getOldValue(RUser::role)).isEqualTo(role)
+        }
+    }
+
+    @Test
+    fun oldLinkValueOnNonSnapshotReferenceAfterClearThenDelete() {
+        val (user, role) = store.transactional {
+            val role = RRole.new()
+            val user = RUser.new(name).apply { this.role = role }
+            Pair(user, role)
+        }
+        store.transactional {
+            user.role = null
+            user.delete()
+            assertThat(user.getOldValue(RUser::role)).isEqualTo(role)
+        }
+    }
+
+    @Test
+    fun oldLinkValueInRemovedSyncListener() {
+        val (user, role) = store.transactional {
+            val role = RRole.new()
+            val user = RUser.new(name).apply { this.role = role }
+            Pair(user, role)
+        }
+
+        var capturedOldRole: RRole? = null
+        store.changesMultiplexer!!.addListener(RUser, object : XdEntityListener<RUser> {
+            override fun removedSync(removed: RUser) {
+                capturedOldRole = removed.getOldValue(RUser::role)
+            }
+        })
+
+        store.transactional { user.delete() }
+
+        assertThat(capturedOldRole).isEqualTo(role)
     }
 }

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/SortedByTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/SortedByTest.kt
@@ -103,6 +103,27 @@ class SortedByTest : DBTest() {
         )
     }
 
+    /**
+     * Regression test for: linked-sort overload of SortEngine.sort blows up on an empty
+     * YTDBEntityIterable.
+     *
+     * Root cause: SortEngine.sort(enumType, propName, entityType, linkName, source, asc)
+     * peeks at `source.query` to decide whether to delegate to sortLinked. When the source
+     * unwraps to YTDBEntityIterable.EMPTY, `.query` is stubbed to throw
+     * UnsupportedOperationException("Should never be called"). The sibling property-sort
+     * overload already short-circuits to EMPTY for an empty source; the linked-sort overload
+     * is missing that guard.
+     */
+    @Test
+    fun `linked sort on empty result does not throw`() {
+        transactional {
+            val empty = User.emptyQuery()
+                .sortedBy(User::badge, Badge::name, asc = true)
+                .toList()
+            assertThat(empty).isEmpty()
+        }
+    }
+
     private fun checkOrder(
         name: String,
         queryOrder: XdQuery<User>.() -> XdQuery<User>,


### PR DESCRIPTION
## Summary

Bundles four related YTDB-migration regression fixes for the listener / snapshot read paths:

- **Snapshot link state on REMOVE entities** — `YTDBVertexEntityRemoved.init` now overlays `LinkChange` records onto the live vertex when building its `links` map, so `snapshot.getLink/getLinks` reflect pre-transaction state even when `setManyToOne(null)` / `setLink` / `addLink` / `deleteLinks` ran earlier in the same transaction. Mirrors the UPDATE-snapshot fix from `0b565c7e`.
- **Delete after intermediate flush** — `EntityOperations.remove` upgrades the read-only transaction before calling `entityBeforeRemoved`, and `ReadOnlyTransientChangesTrackerImpl.entityBeforeRemoved` now throws to enforce the upgrade contract (was silently no-op, dropping the removal snapshot).
- **`getOldLinkValue` on removed entities** — reads from the in-memory removal snapshot instead of re-fetching from the persistent store (which throws `EntityRemovedInDatabaseException` under YTDB after flush).
- **Linked-sort empty source** — `SortEngine.sort` linked-sort overload short-circuits when the source unwraps to `YTDBEntityIterable.EMPTY`, matching the existing guard in the property-sort overload.
