### PR TITLE
XD-1272 Capture removed-entity blob bytes before YTDB session closes

### DIFF
--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/YTDBVertexEntityRemoved.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/YTDBVertexEntityRemoved.kt
@@ -15,6 +15,7 @@
  */
 package com.jetbrains.teamsys.dnq.database
 
+import com.jetbrains.youtrackdb.internal.core.record.impl.RecordBytes
 import jetbrains.exodus.database.TransientEntity
 import jetbrains.exodus.entitystore.Entity
 import jetbrains.exodus.entitystore.EntityId
@@ -24,6 +25,8 @@ import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
 import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBEntityIterable
 import jetbrains.exodus.query.InMemoryEntityIterable
 import jetbrains.exodus.query.QueryEngine
+import jetbrains.exodus.util.UTFUtil
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream
 
@@ -43,6 +46,20 @@ class YTDBVertexEntityRemoved(
 ) {
 
     private val links = mutableMapOf<String, Set<EntityId>>()
+
+    /**
+     * Snapshot of blob bytes captured at construction time, before the YTDB session that owns
+     * the underlying `RecordBytes` is closed. YTDB calls `RecordAbstract.unload()` on its cached
+     * records when the session closes, resetting `status` to `NOT_LOADED` and clearing `source`.
+     * Without this eager copy, a flushed-sync listener that reads a blob field on the snapshot
+     * would trip `RecordAbstract.checkForBinding` with
+     * `Record #X:Y is not bound to the current session` (XD-1272).
+     *
+     * Regular scalar properties (String, Long, …) don't need this — they are stored inline on
+     * the vertex, `YTDBDetachedVertex` copies their values by reference, and the JVM objects
+     * are unaffected by YTDB session lifecycle.
+     */
+    private val blobBytes: Map<String, ByteArray> = captureBlobBytes(originalVertex, store)
 
     init {
         // The live vertex reflects post-mutation state at delete() time. To get the
@@ -65,6 +82,17 @@ class YTDBVertexEntityRemoved(
             }
         }
     }
+
+    override fun getBlob(blobName: String): InputStream? =
+        blobBytes[blobName]?.let { ByteArrayInputStream(it) }
+
+    override fun getBlobString(blobName: String): String? =
+        blobBytes[blobName]?.let { UTFUtil.readUTF(ByteArrayInputStream(it)) }
+
+    override fun getBlobSize(blobName: String): Long =
+        blobBytes[blobName]?.size?.toLong() ?: -1L
+
+    override fun getBlobNames(): List<String> = blobBytes.keys.toList()
 
     override fun getLinkNames(): List<String> = links.keys.toList()
 
@@ -136,4 +164,42 @@ class YTDBVertexEntityRemoved(
     private fun vertexIsRemoved(): Nothing {
         throw IllegalArgumentException("Already deleted")
     }
+}
+
+/**
+ * Reads each blob property's bytes into a JVM-owned `ByteArray` while the YTDB session that
+ * owns the underlying [RecordBytes] is still active. The returned map outlives the session,
+ * so the snapshot can serve blob reads after `session.close()` (which calls
+ * `RecordAbstract.unload()` on every cached record).
+ *
+ * Force-loads each [RecordBytes] via `transaction.getBlob(rid)` before reading, because the
+ * record may still be in `NOT_LOADED` state if nothing on the entity's caller path materialised
+ * its bytes before removal.
+ */
+private fun captureBlobBytes(
+    originalVertex: YTDBVertexEntity,
+    store: YTDBEntityStore
+): Map<String, ByteArray> {
+    val vertex = originalVertex.vertex
+    if (vertex is YTDBDetachedVertex) {
+        // Re-snapshotting an already-detached vertex: the bytes were captured by the upstream
+        // snapshot already, and we no longer have access to a live session to re-read them.
+        return emptyMap()
+    }
+
+    val result = mutableMapOf<String, ByteArray>()
+    val txn = store.requireActiveTransaction()
+    vertex.properties<Any>().forEachRemaining { prop ->
+        val value = prop.value()
+        if (value is RecordBytes) {
+            val rid = value.identity
+            if (rid.isValidPosition) {
+                // getBlob → session.load(rid) → ensures status == LOADED and source != null,
+                // even if the entity caller never touched this blob before removing the entity.
+                val loaded = txn.getBlob(rid) as RecordBytes
+                result[prop.key()] = loaded.toStream()
+            }
+        }
+    }
+    return result
 }

--- a/dnq/src/test/kotlin/kotlinx/dnq/RemovedTransientEntityTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/RemovedTransientEntityTest.kt
@@ -17,8 +17,13 @@ package kotlinx.dnq
 
 import com.jetbrains.teamsys.dnq.database.threadSessionOrThrow
 import jetbrains.exodus.database.TransientEntity
+import kotlinx.dnq.listener.XdEntityListener
+import kotlinx.dnq.listener.addListener
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RemovedTransientEntityTest : DBTest() {
@@ -41,5 +46,76 @@ class RemovedTransientEntityTest : DBTest() {
             assertTrue(snapshot.isRemoved)
             assertEquals("alice", snapshot.getPropertyOldValue("login"))
         }
+    }
+
+    /**
+     * Reproducer for XD-1272.
+     *
+     * A flushed-sync listener that reads a blob field on the [RemovedTransientEntity] snapshot
+     * triggers `RecordAbstract.checkForBinding` and throws
+     * `Record #<rid> is not bound to the current session` when the underlying YTDB
+     * `RecordBytes` was never loaded into memory before the entity was removed.
+     *
+     * Production stack (Hub pre-merge):
+     *   YTDBVertexEntity.getBlob -> RecordBytes.toStream -> checkForBinding (NOT_LOADED) -> throw
+     *   <- RemovedTransientEntity.getBlob
+     *   <- reattachAndGetBlob (XdTextProperty.isDefined / XdURLAvatar.getAvatarURL)
+     *   <- JetPassEventListener.handleChange (flushed listener)
+     *   <- TransientSessionImpl.notifyFlushedListeners -> flush()
+     */
+    @Test
+    fun `flushed listener can read blob bytes from removed entity snapshot`() {
+        val image = store.transactional {
+            Image.new {
+                content = "hello"
+            }
+        }
+
+        val captured = AtomicReference<String?>()
+        Image.addListener(store, object : XdEntityListener<Image> {
+            override fun removedSync(removed: Image) {
+                // Reads the blob through the RemovedTransientEntity snapshot:
+                //   XdTextProperty.getValue -> reattachAndGetBlobString -> RemovedTransientEntity.getBlobString
+                //   -> YTDBVertexEntity.getBlobString -> RecordBytes.toStream
+                captured.set(removed.content)
+            }
+        })
+
+        // Re-attach in a new session so the blob's RecordBytes stays NOT_LOADED
+        // until the listener fires after flush.
+        store.transactional {
+            image.delete()
+        }
+
+        assertEquals("hello", captured.get())
+    }
+
+    /**
+     * Same flushed-listener scenario as [flushed listener can read blob bytes from removed entity snapshot],
+     * but for a regular (non-blob) String property. Regular properties are stored inline on the
+     * vertex (no separate `RecordBytes`), so this scenario should NOT hit the "not bound to session"
+     * error — the snapshot must return the pre-removal value.
+     */
+    @Test
+    fun `flushed listener can read regular String property from removed entity snapshot`() {
+        val user = store.transactional {
+            User.new {
+                login = "alice"
+                skill = 1
+            }
+        }
+
+        val captured = AtomicReference<String?>()
+        User.addListener(store, object : XdEntityListener<User> {
+            override fun removedSync(removed: User) {
+                captured.set(removed.login)
+            }
+        })
+
+        store.transactional {
+            user.delete()
+        }
+
+        assertEquals("alice", captured.get())
     }
 }


### PR DESCRIPTION
## Summary

- Fix [XD-1272](https://youtrack.jetbrains.com/issue/XD-1272): a flushed-sync listener reading a blob field on a `RemovedTransientEntity` snapshot threw `DatabaseException: Record #X:Y is not bound to the current session`.
- `YTDBVertexEntityRemoved` now copies each blob's bytes into a JVM-owned `Map<String, ByteArray>` at snapshot construction (force-loading via `transaction.getBlob(rid)` first), and overrides `getBlob` / `getBlobString` / `getBlobSize` / `getBlobNames` to serve from it.

## Root cause

`YTDBDetachedVertex` captures property values by reference. For blobs the value is a `RecordBytes`. When the YTDB session closes, `RecordAbstract.unload()` blanks `source` and resets `status` to `NOT_LOADED` on the very same instance the detached vertex holds. A later read via `RecordBytes.toStream → checkForBinding` then throws.

Pre-loading via `txn.getBlob(rid)` alone is not enough — the cached record gets unloaded out from under us at session close. The bytes must be copied out.

Regular scalar properties (String, Long, etc.) are unaffected: `YTDBDetachedVertexProperty.detach` captures their materialised JVM values, which the YTDB session lifecycle never touches.

## Test plan

- [x] `kotlinx.dnq.RemovedTransientEntityTest.flushed listener can read blob bytes from removed entity snapshot` — reproducer, fails before the fix with the exact production stack
- [x] `kotlinx.dnq.RemovedTransientEntityTest.flushed listener can read regular String property from removed entity snapshot` — contrast test confirming regular properties already work
- [x] `kotlinx.dnq.RemovedTransientEntityTest.getPropertyOldValue on snapshot of removed entity returns pre-removal value` — pre-existing test still green
- [x] Full `./gradlew :dnq:test` (6m 57s) — no regressions
- [x] Full `./gradlew build` — green