### PR TITLE
Fix empty ByIds GremlinQuery returning all vertices instead of none

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
@@ -178,8 +178,11 @@ sealed class GremlinQuery {
     // todo: think how to preserve the order of the parameters
     // todo: handle Take & Skip differently too
     data class ByIds(val ids: List<RID>) : Condition(GremlinBlock.IdWithin(ids)) {
+        // gs.V() with no IDs traverses every vertex — wrong for an empty by-IDs query
+        // (which can arise from optimiser reductions like ByIds(x).difference(ByIds(x))).
         override fun startTraversal(gs: GraphTraversalSource): YTBuilder =
-            YTBuilder(gs.V(*ids.toTypedArray()).asYT(), 0)
+            if (ids.isEmpty()) YTBuilder.of(gs.V(), GremlinBlock.None)
+            else YTBuilder(gs.V(*ids.toTypedArray()).asYT(), 0)
     }
 
     data class NestedCondition(val structure: List<String>, val condition: Condition) : Condition(

--- a/dnq/src/test/kotlin/kotlinx/dnq/query/coverage/GremlinQueryCoverageTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/query/coverage/GremlinQueryCoverageTest.kt
@@ -407,6 +407,13 @@ class GremlinQueryCoverageTest : DBTest() {
             // Q22: {ENG-1,ENG-2} \ {ENG-2} = ENG-1
             assertThat(ByIds(listOf(eng1Rid, eng2Rid)).difference(ByIds(listOf(eng2Rid))).resultKeys(tx))
                 .containsExactly("ENG-1")
+            // Q22b: {ENG-1} \ {ENG-1} = ∅. Regression for the ByIds(emptyList()) → g.V()
+            // bug where the optimiser-reduced empty by-IDs query executed as "all vertices"
+            // instead of "no vertices", surfacing as XdQuery.exclude returning everything.
+            // Iterate the raw entity iterable so a non-empty result is observable directly
+            // (resultKeys would NPE on non-Issue vertices, masking the actual count).
+            assertThat(YTDBEntityIterable.query(tx, ByIds(listOf(eng1Rid)).difference(ByIds(listOf(eng1Rid)))).toList())
+                .isEmpty()
         }
     }
 


### PR DESCRIPTION
## Summary
- `ByIds.startTraversal` called `gs.V(*ids.toTypedArray())`; on an empty `ids` list the vararg expanded to `gs.V()` — Gremlin's "all vertices in the graph" — rather than the intended "no vertices match".
- Empty `ByIds` arises naturally from optimiser reductions such as `ByIds(x).difference(ByIds(x)) → ByIds(emptyList())`. At higher levels this surfaced as `XdQuery.exclude` returning every entity in the DB when subtracting an equivalent query.
- Route the empty case through `GremlinBlock.None` so the traversal discards immediately — consistent with how the rest of the codebase represents "no results".