### PR TITLE
Fix readonly wrapping of live link targets navigated from snapshot entities

### DIFF
--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadonlyTransientEntity.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/ReadonlyTransientEntity.kt
@@ -98,12 +98,12 @@ class ReadonlyTransientEntity(change: TransientEntityChange?, snapshot: YTDBEnti
         val change = changedLinks[linkName]
         if (change != null) {
             change.removedEntities?.firstOrNull()
-                ?.let { return SnapshotEntityIterator.wrapEntity(it, store) }
+                ?.let { return SnapshotEntityIterator.wrapLinkTarget(it, store) }
             change.deletedEntitiesSnapshots?.firstOrNull()
                 ?.let { return it }
             return null
         }
-        return entity.getLink(linkName)?.let { SnapshotEntityIterator.wrapEntity(it, store) }
+        return entity.getLink(linkName)?.let { SnapshotEntityIterator.wrapLinkTarget(it, store) }
     }
 
     override fun getLink(linkName: String, session: TransientStoreSession?): Entity? {

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/RemovedTransientEntity.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/RemovedTransientEntity.kt
@@ -248,7 +248,7 @@ open class RemovedTransientEntity(
     }
 
     override fun getLink(linkName: String): Entity? = entity.getLink(linkName)
-        ?.let { SnapshotEntityIterator.wrapEntity(it, store) }
+        ?.let { SnapshotEntityIterator.wrapLinkTarget(it, store) }
 
     override fun getLinks(linkName: String): EntityIterable =
         SnapshotEntityIterable(entity.getLinks(linkName), store)

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
@@ -99,6 +99,24 @@ internal class SnapshotEntityIterator(
             is YTDBEntity -> ReadonlyTransientEntity(entity, store)
             else -> entity
         }
+
+        /**
+         * Wraps a target reached by single-link navigation from a snapshot entity
+         * ([ReadonlyTransientEntity.getLink], [RemovedTransientEntity.getLink]).
+         *
+         * Live targets are returned as writable [TransientEntity]s so post-flush
+         * listeners can mutate them (e.g. cascade-cleanup an orphaned linked entity
+         * from `removedSync`). Targets that have themselves been removed in the
+         * current transaction stay read-only because the underlying entity is gone.
+         *
+         * [wrapEntity] is kept for iteration paths ([SnapshotEntityIterator],
+         * [SnapshotEntityIterable]) where the snapshot collection view is preserved.
+         */
+        fun wrapLinkTarget(entity: Entity, store: TransientEntityStore): Entity = when (entity) {
+            is YTDBVertexEntityRemoved -> RemovedTransientEntity(entity, store)
+            is YTDBEntity -> store.threadSession?.newEntity(entity) ?: ReadonlyTransientEntity(entity, store)
+            else -> entity
+        }
     }
 
     override fun next(): Entity = wrapEntity(original.next(), store)

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
@@ -109,12 +109,25 @@ internal class SnapshotEntityIterator(
          * from `removedSync`). Targets that have themselves been removed in the
          * current transaction stay read-only because the underlying entity is gone.
          *
+         * A writable handle is only minted when the current session can actually
+         * back it: the session must be open, and it must not already know the target
+         * as removed. The removed case matters when the link edge still exists at
+         * navigation time (e.g. an [kotlinx.dnq.link.OnDeletePolicy.FAIL] target
+         * deleted in the same transaction, seen from a before-flush listener) —
+         * without the check the caller would get a writable handle onto an entity
+         * the changes tracker considers gone, and writes to it would appear to
+         * succeed. This mirrors the guard [TransientEntityImpl.getLink] already
+         * applies on the live navigation path.
+         *
          * [wrapEntity] is kept for iteration paths ([SnapshotEntityIterator],
          * [SnapshotEntityIterable]) where the snapshot collection view is preserved.
          */
         fun wrapLinkTarget(entity: Entity, store: TransientEntityStore): Entity = when (entity) {
             is YTDBVertexEntityRemoved -> RemovedTransientEntity(entity, store)
-            is YTDBEntity -> store.threadSession?.newEntity(entity) ?: ReadonlyTransientEntity(entity, store)
+            is YTDBEntity -> store.threadSession
+                ?.takeIf { it.isOpened && !it.transientChangesTracker.isRemoved(entity.id) }
+                ?.newEntity(entity)
+                ?: ReadonlyTransientEntity(entity, store)
             else -> entity
         }
     }

--- a/dnq/src/test/kotlin/kotlinx/dnq/SnapshotLinkTargetTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/SnapshotLinkTargetTest.kt
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import jetbrains.exodus.database.EntityChangeType
+import jetbrains.exodus.database.TransientEntity
+import jetbrains.exodus.database.TransientEntityChange
+import jetbrains.exodus.database.TransientStoreSession
+import jetbrains.exodus.database.TransientStoreSessionListener
+import jetbrains.exodus.database.exceptions.DataIntegrityViolationException
+import jetbrains.exodus.entitystore.Entity
+import kotlinx.dnq.link.OnDeletePolicy
+import kotlinx.dnq.util.getDBName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Counterpart to the writable-target cases in [TransientStoreSessionListenerTest]: navigating a
+ * to-one link off a snapshot entity hands back a *writable* handle only when the current session
+ * can actually back it.
+ *
+ * The case that needs its own model is a target removed in the same transaction whose link edge is
+ * still in place at navigation time. With [OnDeletePolicy.CLEAR] (the policy the other test model
+ * uses) the edge is stripped and the navigation already lands on a `YTDBVertexEntityRemoved`
+ * snapshot. With [OnDeletePolicy.FAIL] the edge survives until the constraint check, so navigation
+ * reaches a still-alive vertex that the changes tracker nevertheless considers removed. That handle
+ * must stay read-only — otherwise writes against an entity that is on its way out appear to
+ * succeed.
+ */
+class SnapshotLinkTargetTest : DBTest() {
+
+    class FailPolicyTarget(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<FailPolicyTarget>()
+
+        var name by xdRequiredStringProp()
+    }
+
+    class FailPolicySource(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<FailPolicySource>()
+
+        var name by xdRequiredStringProp()
+        var target by xdLink0_1(FailPolicyTarget, onTargetDelete = OnDeletePolicy.FAIL)
+    }
+
+    override fun registerEntityTypes() {
+        XdModel.registerNodes(FailPolicyTarget, FailPolicySource)
+    }
+
+    private class NavigatingListener : TransientStoreSessionListener {
+        var navigated: Entity? = null
+        var writeOutcome: String? = null
+        var readBack: Comparable<*>? = null
+
+        override fun beforeFlushBeforeConstraints(
+            session: TransientStoreSession,
+            changedEntities: Set<TransientEntityChange>
+        ) {
+            val change = changedEntities.singleOrNull {
+                it.changeType == EntityChangeType.UPDATE &&
+                        it.transientEntity.type == FailPolicySource.entityType
+            } ?: return
+            val target = change.snapshotEntity.getLink(FailPolicySource::target.getDBName()) ?: return
+            navigated = target
+            readBack = target.getProperty("name")
+            writeOutcome = try {
+                target.setProperty("name", "written-through-snapshot")
+                "written"
+            } catch (e: IllegalStateException) {
+                "rejected: ${e.message}"
+            }
+        }
+
+        override fun flushed(session: TransientStoreSession, changedEntities: Set<TransientEntityChange>) {}
+
+        override fun afterConstraintsFail(
+            session: TransientStoreSession,
+            exceptions: Set<DataIntegrityViolationException>
+        ) {
+        }
+    }
+
+    @Test
+    fun `snapshot navigation to a target removed in the same transaction stays read-only`() {
+        val (target, source) = store.transactional {
+            val target = FailPolicyTarget.new { name = "target" }
+            val source = FailPolicySource.new { name = "source"; this.target = target }
+            target to source
+        }
+
+        val listener = NavigatingListener()
+        store.addListener(listener)
+        try {
+            store.transactional {
+                // the source must be changed too, so that it shows up as an UPDATE in the
+                // changes description and the listener gets a snapshot to navigate from
+                source.name = "source-renamed"
+                target.delete()
+            }
+            fail("the FAIL policy must reject deleting a target that is still linked")
+        } catch (e: Exception) {
+            // expected: constraint validation rejects the delete
+        } finally {
+            store.removeListener(listener)
+        }
+
+        val navigated = listener.navigated ?: fail("listener did not navigate to the target")
+        assertEquals(target.entityId, navigated.id)
+        assertTrue(
+            (navigated as TransientEntity).isReadonly,
+            "a target the changes tracker already knows as removed must not be handed out as writable"
+        )
+        assertEquals(
+            "rejected: Entity is readonly",
+            listener.writeOutcome,
+            "writing through the snapshot to a removed target must be rejected, not silently accepted"
+        )
+        // the snapshot read still works — only mutation is refused
+        assertEquals("target", listener.readBack)
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransientStoreSessionListenerTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransientStoreSessionListenerTest.kt
@@ -20,6 +20,8 @@ import jetbrains.exodus.database.*
 import jetbrains.exodus.database.exceptions.DataIntegrityViolationException
 import jetbrains.exodus.entitystore.Entity
 import kotlinx.dnq.link.OnDeletePolicy
+import kotlinx.dnq.listener.XdEntityListener
+import kotlinx.dnq.listener.addListener
 import kotlinx.dnq.query.isEmpty
 import kotlinx.dnq.query.queryOf
 import kotlinx.dnq.query.toList
@@ -594,6 +596,156 @@ class TransientStoreSessionListenerTest : DBTest() {
             child.delete()
         }
         listener.check()
+    }
+
+    @Test
+    fun `snapshot of removed entity returns writable target for unchanged to-one link`() {
+        // The removed snapshot's to-one link target is itself alive (not deleted in
+        // the same transaction). Listeners must be able to mutate it — the canonical
+        // pattern is `removedSync(removed) { removed.linkedResource.delete() }` for
+        // orphan cleanup.
+        val parent = store.transactional { LevelOneEntity.new { name = "parent" } }
+        val child = store.transactional { LevelTwoEntity.new { name = "child"; this.parent = parent } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.REMOVE && it.transientEntity.id == child.entityId
+            } ?: error("expected REMOVE change for child")
+            val navigated = childChange.snapshotEntity.getLink("parent")
+                ?: error("expected navigated parent")
+            assertEquals(parent.entityId, navigated.id)
+            assertFalse(
+                (navigated as TransientEntity).isReadonly,
+                "navigated live target must be writable so removedSync can mutate it"
+            )
+        }
+
+        store.transactional { child.delete() }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot of removed entity returns read-only target for to-one link whose target was also removed`() {
+        // Both the source and the link target are deleted in the same transaction.
+        // The navigated entity must stay read-only because the underlying vertex is
+        // gone — there is no live entity to wrap. Anchors the contract that
+        // wrapLinkTarget still produces a snapshot wrapper for removed targets.
+        val (parent, child) = store.transactional {
+            val p = LevelOneEntity.new { name = "parent" }
+            val c = LevelTwoEntity.new { name = "child"; this.parent = p }
+            p to c
+        }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.REMOVE && it.transientEntity.id == child.entityId
+            } ?: error("expected REMOVE change for child")
+            val navigated = childChange.snapshotEntity.getLink("parent")
+                ?: error("expected snapshot of removed parent")
+            assertEquals(parent.entityId, navigated.id)
+            assertTrue(
+                (navigated as TransientEntity).isReadonly,
+                "navigated target that was deleted in the same txn must remain a read-only snapshot"
+            )
+        }
+
+        store.transactional {
+            child.delete()
+            parent.delete()
+        }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot of updated entity returns writable target for unchanged to-one link`() {
+        // The UPDATE snapshot path (ReadonlyTransientEntity.getLink, change == null
+        // branch). Listener mutates a property of the navigated-to entity reached
+        // from the snapshot — must succeed because the navigated entity is live.
+        val parent = store.transactional { LevelOneEntity.new { name = "parent" } }
+        val child = store.transactional { LevelTwoEntity.new { name = "child"; this.parent = parent } }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.UPDATE && it.transientEntity.id == child.entityId
+            } ?: error("expected UPDATE change for child")
+            val navigated = childChange.snapshotEntity.getLink("parent")
+                ?: error("expected navigated parent")
+            assertEquals(parent.entityId, navigated.id)
+            assertFalse(
+                (navigated as TransientEntity).isReadonly,
+                "navigated live target must be writable on the UPDATE snapshot path"
+            )
+        }
+
+        store.transactional { child.name = "renamed" }
+        listener.check()
+    }
+
+    @Test
+    fun `snapshot of updated entity returns writable target for to-one link that was reassigned`() {
+        // The UPDATE snapshot path with LinkChange.removedEntities (the link was
+        // reassigned to a different target). The snapshot must point to the OLD
+        // target and that OLD target must be writable — listeners may need to
+        // clean it up if the reassignment leaves it orphaned.
+        val (oldParent, newParent, child) = store.transactional {
+            val p1 = LevelOneEntity.new { name = "oldParent" }
+            val p2 = LevelOneEntity.new { name = "newParent" }
+            val c = LevelTwoEntity.new { name = "child"; parent = p1 }
+            Triple(p1, p2, c)
+        }
+
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        listener.onFlush { changes ->
+            val childChange = changes.singleOrNull {
+                it.changeType == EntityChangeType.UPDATE && it.transientEntity.id == child.entityId
+            } ?: error("expected UPDATE change for child")
+            val navigated = childChange.snapshotEntity.getLink("parent")
+                ?: error("expected navigated old parent")
+            assertEquals(oldParent.entityId, navigated.id)
+            assertFalse(
+                (navigated as TransientEntity).isReadonly,
+                "old to-one link target must be writable when the link was reassigned"
+            )
+        }
+
+        store.transactional { child.parent = newParent }
+        listener.check()
+    }
+
+    @Test
+    fun `removedSync listener can delete the navigated link target of the removed snapshot`() {
+        // End-to-end: combines the snapshot-navigation wrap with the EntityOperations.remove
+        // path that XdEntity.delete() goes through. Production listeners (e.g.
+        // CustomFieldDefaultsListener -> XdBundle.removeIfUnused) rely on this pattern to
+        // clean up orphaned linked entities after the owner is removed.
+        val parent = store.transactional { LevelOneEntity.new { name = "parent" } }
+        val child = store.transactional { LevelTwoEntity.new { name = "child"; this.parent = parent } }
+
+        LevelTwoEntity.addListener(store, object : XdEntityListener<LevelTwoEntity> {
+            override fun removedSync(removed: LevelTwoEntity) {
+                removed.parent?.delete()
+            }
+        })
+
+        store.transactional { child.delete() }
+
+        store.transactional {
+            assertTrue(
+                LevelOneEntity.all().isEmpty,
+                "parent must have been deleted by the removedSync listener"
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`ReadonlyTransientEntity.getLink` and `RemovedTransientEntity.getLink` wrapped their result via `SnapshotEntityIterator.wrapEntity`, which unconditionally produces a `ReadonlyTransientEntity`. The navigated-to entity therefore always came back read-only — even when the underlying vertex was alive — and `removedSync` listeners that tried to clean up an orphaned linked entity hit `IllegalStateException: Entity is readonly`.

This PR adds a sibling helper `SnapshotEntityIterator.wrapLinkTarget` that returns a writable `TransientEntityImpl` for live targets and keeps `RemovedTransientEntity` only for targets that were themselves removed in the same transaction. Iteration paths (`SnapshotEntityIterator.next`, `SnapshotEntityIterable.getFirst/getLast`) still go through `wrapEntity`, so the read-only snapshot collection view that existing to-many tests rely on is preserved.

Complements 0b565c7e (which fixed *which value* `getLink` returns from the post-flush tracker) — this commit fixes *whether the caller can mutate the returned entity*. Both invariants are now asserted side-by-side.

## Changes

- `dnq-transient-store/.../SnapshotEntityIterable.kt` — add `wrapLinkTarget`.
- `dnq-transient-store/.../ReadonlyTransientEntity.kt` — `getLink` (both `change != null` and `change == null` branches) routes live targets through `wrapLinkTarget`; `deletedEntitiesSnapshots` keeps returning the captured snapshot.
- `dnq-transient-store/.../RemovedTransientEntity.kt` — `getLink` routes through `wrapLinkTarget`.
- `dnq/src/test/kotlin/kotlinx/dnq/TransientStoreSessionListenerTest.kt` — 5 new tests covering each branch of the new helper and an end-to-end `removedSync` mutation case.
