### PR TITLE
XD-1278 Restore GetAll-identity short-circuit in QueryEngine.intersect

### DIFF
--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
@@ -128,9 +128,80 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
         if (left.isEmpty) return YTDBEntityIterable.EMPTY
         if (right.isEmpty) return YTDBEntityIterable.EMPTY
 
+        // XD-1278: restore the Xodus GetAll-identity short-circuit. Intersecting GetAll(type) with
+        // another iterable must preserve that other iterable's iteration order. The general/DB
+        // intersect path imposes entity-id order (e.g. it rewrites a relevance-ordered by-ids
+        // operand into g.V().hasId(within(ids)).hasLabel(type), which loses the relevance order),
+        // and inMemoryIntersect only preserves the LEFT operand's order. Applied symmetrically:
+        // GetAll ∩ x → x and x ∩ GetAll → x, each filtered to live entities of the type.
+        intersectWithGetAll(getAll = left, other = right)?.let { return it }
+        intersectWithGetAll(getAll = right, other = left)?.let { return it }
+
         return if (canAggregate(left, right))
             (left as EntityIterable).intersect(right as EntityIterable)
         else inMemoryIntersect(left, right)
+    }
+
+    private data class GetAllInfo(val type: String, val polymorphic: Boolean)
+
+    /**
+     * If [getAll] is a `GetAll(type)` iterable (an unwrapped [YTDBEntityIterable] whose query is
+     * `Labeled(Where(All), type)`), return [other] filtered to the live entities of that type,
+     * preserving [other]'s iteration order. Returns `null` when [getAll] is not a GetAll, or when
+     * the case is better handled by the regular intersect path (so the caller falls through).
+     */
+    private fun intersectWithGetAll(getAll: Iterable<Entity>, other: Iterable<Entity>): Iterable<Entity>? {
+        val info = getAll.asGetAll() ?: return null
+
+        val otherUnwrapped = (other as? EntityIterable)?.unwrap()
+        if (otherUnwrapped is YTDBEntityIterable && otherUnwrapped !== YTDBEntityIterable.EMPTY) {
+            val query = otherUnwrapped.query
+            when {
+                // `other` is already a DB query of exactly this type with the same polymorphism:
+                // GetAll(type) ∩ other == other (other only yields live, type-compatible entities,
+                // in its own order). Returned as the unwrapped iterable so the common
+                // `all().query { cond }` path keeps its lazy DB iterable and is not materialized.
+                // (We must return the unwrapped form: callers such as XdQueryEngine re-wrap the
+                // result, and wrapping an already-wrapped transient iterable is rejected.)
+                query is GremlinQuery.Labeled && query.label == info.type &&
+                        otherUnwrapped.polymorphic == info.polymorphic -> return otherUnwrapped
+                // `other` is a relevance/explicitly-ordered by-ids operand (e.g. full-text search
+                // hits). It is bounded, so filter it in memory below, preserving its order.
+                query is GremlinQuery.ByIds -> Unit
+                // `other` is some other DB-backed query (e.g. a typed query of a different label):
+                // let the regular DB intersect handle it rather than materialising a possibly-large
+                // set. Order is not meaningful across unrelated types.
+                else -> return null
+            }
+        }
+
+        // Filter `other` to live entities of `type`, preserving order. Membership is resolved with a
+        // single bounded query over `other`'s ids (V(ids).hasLabel(type)) instead of materialising
+        // the whole GetAll set; this also reproduces the dead/stale-entity exclusion (stale ids are
+        // simply absent from the membership set).
+        val txn = persistentStore.andCheckCurrentTransaction
+        val materialized = other.toList()
+        if (materialized.isEmpty()) return YTDBEntityIterable.EMPTY
+
+        val rids = materialized.map { (it.id as YTDBEntityId).asOId() }
+        val liveOfType = YTDBEntityIterable
+            .query(
+                oStore,
+                GremlinQuery.ByIds(rids).then(GremlinBlock.HasLabel(info.type)),
+                info.polymorphic
+            )
+            .idSet()
+        val result = materialized.filter { it.id in liveOfType }
+        return InMemoryEntityIterable(result, txn = txn, this)
+    }
+
+    private fun Iterable<Entity>.asGetAll(): GetAllInfo? {
+        val unwrapped = (this as? EntityIterable)?.unwrap()
+        if (unwrapped !is YTDBEntityIterable || unwrapped === YTDBEntityIterable.EMPTY) return null
+        val query = unwrapped.query as? GremlinQuery.Labeled ?: return null
+        val inner = query.inner
+        if (inner !is GremlinQuery.Where || inner.block !is GremlinBlock.All) return null
+        return GetAllInfo(query.label, unwrapped.polymorphic)
     }
 
     open fun union(left: Iterable<Entity>, right: Iterable<Entity>): Iterable<Entity> {

--- a/dnq-query/src/test/kotlin/jetbrains/exodus/query/OGetAllIntersectOrderTest.kt
+++ b/dnq-query/src/test/kotlin/jetbrains/exodus/query/OGetAllIntersectOrderTest.kt
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.exodus.query
+
+import jetbrains.exodus.entitystore.Entity
+import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityId
+import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
+import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
+import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBEntityIterable
+import jetbrains.exodus.entitystore.youtrackdb.testutil.InMemoryYouTrackDB
+import jetbrains.exodus.entitystore.youtrackdb.testutil.Issues
+import jetbrains.exodus.entitystore.youtrackdb.testutil.OTestMixin
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * XD-1278: intersecting `GetAll(type)` with another iterable must preserve that other iterable's
+ * iteration order (and exclude dead/stale entities). The order-sensitive operand stands in for
+ * full-text search results, whose relevance ranking is intentionally different from entity-id order.
+ */
+class OGetAllIntersectOrderTest : OTestMixin {
+
+    @Rule
+    @JvmField
+    val orientDbRule = InMemoryYouTrackDB()
+
+    override val youTrackDb = orientDbRule
+
+    private fun engine() = QueryEngine(null, youTrackDb.store).apply { sortEngine = SortEngine(this) }
+
+    private fun byIds(tx: YTDBStoreTransaction, vararg entities: Entity): YTDBEntityIterable =
+        YTDBEntityIterable.query(
+            tx.getStore(),
+            GremlinQuery.ByIds(entities.map { (it.id as YTDBEntityId).asOId() })
+        )
+
+    @Test
+    fun `x intersect GetAll preserves the relevance order of x`() {
+        val test = givenTestCase()
+        val engine = engine()
+        withStoreTx { tx ->
+            // relevance order intentionally differs from entity-id (creation) order
+            val ranked = byIds(tx, test.issue3, test.issue1, test.issue2)
+            val all = engine.queryGetAll(Issues.CLASS)
+
+            assertNamesExactlyInOrder(engine.intersect(ranked, all), "issue3", "issue1", "issue2")
+        }
+    }
+
+    @Test
+    fun `GetAll intersect x preserves the relevance order of x`() {
+        val test = givenTestCase()
+        val engine = engine()
+        withStoreTx { tx ->
+            val ranked = byIds(tx, test.issue3, test.issue1, test.issue2)
+            val all = engine.queryGetAll(Issues.CLASS)
+
+            assertNamesExactlyInOrder(engine.intersect(all, ranked), "issue3", "issue1", "issue2")
+        }
+    }
+
+    @Test
+    fun `intersecting GetAll with an in-memory operand excludes stale entities and keeps order`() {
+        val test = givenTestCase()
+        val engine = engine()
+
+        // Hold references in a deliberate order, then delete one of them in a later transaction.
+        val ordered: List<Entity> = listOf(test.issue3, test.issue1, test.issue2)
+        withStoreTx { it.getEntity(test.issue2.id).delete() }
+
+        withStoreTx {
+            val inMemory = InMemoryEntityIterable(ordered, txn = it, engine)
+            val all = engine.queryGetAll(Issues.CLASS)
+
+            // issue2 is stale: excluded. issue3, issue1 kept, in the in-memory order (not id order).
+            assertNamesExactlyInOrder(engine.intersect(all, inMemory), "issue3", "issue1")
+        }
+    }
+
+    @Test
+    fun `GetAll intersect a typed query is unchanged`() {
+        givenTestCase()
+        val engine = engine()
+        withStoreTx {
+            val all = engine.queryGetAll(Issues.CLASS)
+            val issue2 = engine.query(Issues.CLASS, NodeFactory.propEqual("name", "issue2"))
+
+            // GetAll(Issue) ∩ issues(name = issue2) == issues(name = issue2)
+            assertNamesExactly(engine.intersect(all, issue2), "issue2")
+            assertNamesExactly(engine.intersect(issue2, all), "issue2")
+        }
+    }
+
+    @Test
+    fun `GetAll intersect filters out entities of a different type`() {
+        val test = givenTestCase()
+        val engine = engine()
+        withStoreTx { tx ->
+            // a project mixed in among the issue ids — must be dropped by GetAll(Issue)
+            val mixed = byIds(tx, test.issue3, test.project1, test.issue1)
+            val allIssues = engine.queryGetAll(Issues.CLASS)
+
+            assertNamesExactlyInOrder(engine.intersect(mixed, allIssues), "issue3", "issue1")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On the YouTrackDB query engine, intersecting `GetAll(type)` with another iterable does not preserve the other iterable's order:

- the DB intersect collapses the `All` condition and rewrites a relevance-ordered by-ids operand into `g.V().hasId(within(ids)).hasLabel(type)`, which returns entity-id order;
- `inMemoryIntersect` only preserves the **left** operand's order.

So any order-sensitive iterable intersected against "all of a type" loses its order — e.g. full-text search results lose their relevance ranking, because the ranked results are intersected with the all-entities set. Xodus had a `GetAll`-identity short-circuit in `QueryEngine.intersect`; the YouTrackDB migration dropped it.

## Fix

Restore the short-circuit in `QueryEngine.intersect`, applied symmetrically (`GetAll ∩ x → x` and `x ∩ GetAll → x`):

- **Detect** a GetAll operand: an unwrapped `YTDBEntityIterable` whose query is `Labeled(Where(All), type)`.
- If the other operand is **already a DB query of that exact type** with matching polymorphism → return it as-is. This keeps the common `all().query { … }` path lazy and DB-backed, so there is **no performance regression**.
- Otherwise (bounded by-ids relevance hits, or in-memory operands) → filter to live entities of the type using a **single bounded `V(ids).hasLabel(type)` query**, preserving the operand's order and reproducing the dead/stale-entity exclusion (stale ids are simply absent from the membership set — not a naive passthrough).
- A DB-backed typed query of a *different* label falls through to the regular DB intersect (avoids materializing a possibly-large set; cross-type order is not meaningful).

## Tests

New `OGetAllIntersectOrderTest` (dnq-query):
- `x ∩ GetAll` and `GetAll ∩ x` preserve a by-ids relevance order that differs from entity-id order;
- intersecting GetAll with an in-memory operand excludes stale (deleted) entities and keeps order;
- `GetAll ∩ typed-query` is unchanged (passthrough);
- entities of a different type are filtered out.

Each test fails if the fix is reverted. Full `./gradlew build` is green.