### PR TITLE
XD-1279 Generalize allOf(T) ∩ Q to a hasLabel(T) filter (O21)

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQueryOptimizer.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQueryOptimizer.kt
@@ -232,6 +232,57 @@ internal fun GremlinQuery.combineEfficient(
         }
     }
 
+    // O21: allOf(T) ∩ Q — type-filter rewrite (avoids the full-scan Aggregate fallback).
+    //
+    // Intersecting "all vertices of type T" with another query is, by definition, a type filter
+    // on that query.  The identity is general (not link-specific):
+    //
+    //   allOf(T) ∩ Q  ≡  { x ∈ Q : isInstanceOf(x, T) }  =  Q.then(HasLabel(T))
+    //   Where(All) ∩ Q ≡ Q                                  // untyped All ⇒ pure identity
+    //
+    // where allOf(T) = Labeled(Where(All), T) — extractCondition == All and a non-null label —
+    // and bare Where(All) is the label-less identity (extractCondition == All, null label).
+    //
+    // Without this rule, allOf(T) ∩ Q falls to the generic Aggregate { P.within } whenever Q has
+    // no extractable condition (FollowLink, Aggregate, UnionAll, Slice, Order, …).  That Aggregate
+    // drives the traversal from allOf(T) — a full scan of every T vertex — and filters it by
+    // membership in the folded Q set, so a type filter on a (usually small) Q is executed as a scan
+    // of the entire extent of T.  Appending HasLabel(T) to Q instead keeps Q as the driving
+    // traversal and reduces the type check to an inline hasLabel filter.
+    //
+    // Guard `extractCondition(other) == null`: when the other operand HAS an extractable condition
+    // (ByIds → IdWithin, Labeled(Where) → its block, allOf itself → All), the generic condition
+    // combiner at the bottom already handles allOf(T) ∩ Q correctly via `combineBlocks` (a is All
+    // -> b) and does NOT fall to Aggregate.  Scoping O21 to the null-condition operand leaves those
+    // paths untouched — in particular it preserves ByIds ∩ allOf(T) as Labeled(Where(IdWithin), T)
+    // rather than restructuring it.
+    //
+    // Placement:
+    //   - After O_B, which yields a strictly better result for Aggregate ∩ allOf(T): it drops the
+    //     redundant hasLabel entirely rather than appending it.
+    //   - Before O7/O16/O20, which deliberately skip or mishandle an All condBlock (O7's explicit
+    //     `condBlock !is All` guard; O16/O20 would silently drop the T label by appending All).
+    //     Handling allOf(T) here, uniformly, supersedes those edge cases.
+    //
+    // The label-mismatch guard above guarantees that when O21 fires, Q's label is either null or
+    // equal to T, so Q.then(HasLabel(T)) never produces a double-label Labeled(Labeled(_, U), T) —
+    // the OR-merge hazard documented in O19.  Mismatched typed operands stay at Aggregate.
+    //
+    // Example (FollowLink, previously Aggregate):
+    //   Labeled(FollowLink(boards(name=b), IN, "OnBoard"), "Issue") ∩ allOf("Issue")
+    //   → FollowLink(...).then(HasLabel("Issue"))   (label idempotent — Labeled.of flattens)
+    //   → g.V().has("name","b").hasLabel("Board").in("OnBoard_link").hasLabel("Issue")
+    if (condCombiner is ConditionCombiner.Intersect) {
+        if (extractCondition(this) is GremlinBlock.All && extractCondition(other) == null) {
+            val label = extractLabel(this)
+            return if (label != null) other.then(GremlinBlock.HasLabel(label)) else other
+        }
+        if (extractCondition(other) is GremlinBlock.All && extractCondition(this) == null) {
+            val label = extractLabel(other)
+            return if (label != null) this.then(GremlinBlock.HasLabel(label)) else this
+        }
+    }
+
     // O7: FollowLink × Condition fusion — appends a filter predicate directly to the traversal,
     // avoiding a separate Aggregate step for FollowLink ∩ Condition and FollowLink \ Condition.
     //

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryCombineMatrixTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryCombineMatrixTest.kt
@@ -65,6 +65,9 @@ class GremlinQueryCombineMatrixTest {
     private val byids  = ByIds(listOf(rid1, rid2))
     private val byids2 = ByIds(listOf(rid2))
 
+    // allOf(T) — Labeled(Where(All), T): "all vertices of type T"
+    private val allOfIssue = Labeled(GremlinQuery.Where.of(GremlinBlock.All), "Issue")
+
     // SortBy
     private val sorted = SortBy(cond, Sort(Sort.ByProp("name"), SortDirection.ASC))
 
@@ -355,6 +358,28 @@ class GremlinQueryCombineMatrixTest {
         // O17 strips Dedup, O20b fires: extractLabel(byids) = null → else branch.
         check(unionQ, "i", byids, "Dedup(UnionAll)")
         check(byids, "i", unionQ, "Dedup(UnionAll)")
+    }
+
+    // =========================================================================
+    // allOf(T) × others — O21 type-filter rewrite (intersect only)
+    // =========================================================================
+
+    @Test
+    fun `allOf(T) x others — O21 rewrites intersect to a hasLabel filter`() {
+        // ∩ Labeled(Where): extractable condition → generic combiner (not O21); All collapses away.
+        check(allOfIssue, "i", cond, "Labeled(Where)")
+        check(cond, "i", allOfIssue, "Labeled(Where)")
+
+        // ∩ Labeled(FollowLink): no extractable condition → O21 appends hasLabel (was Aggregate).
+        check(allOfIssue, "i", link, "Labeled(FL)")
+        check(link, "i", allOfIssue, "Labeled(FL)")
+
+        // ∩ allOf(T): collapses back to allOf(T).
+        check(allOfIssue, "i", allOfIssue, "Labeled(Where)")
+
+        // ∩ ByIds: extractable (IdWithin) → generic combiner keeps Where(IdWithin), not O21.
+        check(allOfIssue, "i", byids, "Labeled(Where)")
+        check(byids, "i", allOfIssue, "Labeled(Where)")
     }
 
     @Test

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryTest.kt
@@ -16,6 +16,7 @@
 package jetbrains.exodus.entitystore.youtrackdb.query
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock.*
@@ -534,5 +535,145 @@ class GremlinQueryTest {
         // O16 only applies to intersect and difference; union cannot be expressed as a chain extension.
         val result = o7Fused.union(issueCondition("priority", "critical"))
         assertThat(result).isInstanceOf(GremlinQuery.Order::class.java)
+    }
+
+    // O21 — allOf(T) ∩ Q rewrites to Q.then(HasLabel(T)) instead of a full-scan Aggregate
+
+    private fun allOf(label: String): Labeled = Labeled(GremlinQuery.Where.of(All), label)
+
+    private val boardCond = Labeled(GremlinQuery.Where.of(PropEqual("name", "b")), "Board")
+    private val issuesOnBoard = Labeled(FollowLink(boardCond, LinkDirection.IN, "OnBoard"), "Issue")
+    private val issuesOnBoardGremlin =
+        """g.V().has("name","b").hasLabel("Board").in("OnBoard_link").hasLabel("Issue")"""
+
+    @Test
+    fun `O21 - allOf(T) intersect FollowLink appends hasLabel instead of Aggregate`() {
+        val result = allOf("Issue").intersect(issuesOnBoard)
+        assertThat(result).isNotInstanceOf(GremlinQuery.Aggregate::class.java)
+        assertThat(result.toGremlin()).isEqualTo(issuesOnBoardGremlin)
+    }
+
+    @Test
+    fun `O21 - FollowLink intersect allOf(T) appends hasLabel instead of Aggregate`() {
+        // Symmetric: the FollowLink is `this`, allOf is `other`.
+        val result = issuesOnBoard.intersect(allOf("Issue"))
+        assertThat(result).isNotInstanceOf(GremlinQuery.Aggregate::class.java)
+        assertThat(result.toGremlin()).isEqualTo(issuesOnBoardGremlin)
+    }
+
+    @Test
+    fun `O21 - allOf(T) intersect unlabeled FollowLink adds the label`() {
+        // Bare (unlabeled) FollowLink: the type filter materialises as a trailing hasLabel.
+        val bareLink = FollowLink(boardCond, LinkDirection.IN, "OnBoard")
+        val result = allOf("Issue").intersect(bareLink)
+        assertThat(result).isNotInstanceOf(GremlinQuery.Aggregate::class.java)
+        assertThat(result.toGremlin()).isEqualTo(issuesOnBoardGremlin)
+    }
+
+    @Test
+    fun `O21 - bare Where(All) intersect query is pure identity`() {
+        // Untyped All ⇒ no hasLabel appended; the result is the other operand verbatim.
+        val q = issuesOnBoard
+        assertThat(GremlinQuery.all.intersect(q).toGremlin()).isEqualTo(q.toGremlin())
+        assertThat(q.intersect(GremlinQuery.all).toGremlin()).isEqualTo(q.toGremlin())
+    }
+
+    @Test
+    fun `O21 - allOf(T) intersect allOf(T) collapses to allOf(T)`() {
+        val result = allOf("Issue").intersect(allOf("Issue"))
+        assertThat(result.toGremlin()).isEqualTo("""g.V().hasLabel("Issue")""")
+    }
+
+    @Test
+    fun `O21 - allOf(T) intersect condition is left to the generic combiner`() {
+        // Condition has an extractable block, so O21 does NOT fire — combineBlocks(All, cond) = cond.
+        val result = allOf("Issue").intersect(issueCondition("status", "open"))
+        assertThat(result.toGremlin()).isEqualTo("""g.V().has("status","open").hasLabel("Issue")""")
+    }
+
+    @Test
+    fun `O21 - allOf(T) intersect OUT-FollowLink over ByIds rewrites in both operand orders`() {
+        // Mirrors the YouTrack permissions shape:
+        //   Aggregate(Labeled(Where(All), "JPUser"), FollowLink(ByIds, OUT, "viewers"))
+        // O21 must rewrite it to drive from the bounded id set rather than scanning every JPUser,
+        // and must do so regardless of which side the allOf operand is on.
+        val ids = ByIds(listOf(RID.of(40, 1), RID.of(40, 2)))
+        val viewers = FollowLink(ids, LinkDirection.OUT, "viewers")
+
+        listOf(
+            allOf("JPUser").intersect(viewers),  // allOf on the left  → O21 branch 1
+            viewers.intersect(allOf("JPUser")),   // operands switched   → O21 branch 2 (symmetric)
+        ).forEach { result ->
+            assertThat(result).isNotInstanceOf(GremlinQuery.Aggregate::class.java)
+            assertThat(result).isInstanceOf(Labeled::class.java)
+            val labeled = result as Labeled
+            assertThat(labeled.label).isEqualTo("JPUser")
+            // The exact FollowLink is preserved as the driving traversal; only a hasLabel is added.
+            assertThat(labeled.inner).isEqualTo(viewers)
+        }
+    }
+
+    @Test
+    fun `O21 - allOf(T) intersect Slice applies the type filter after the page`() {
+        // Paging case: the type filter must be appended AFTER the skip, matching the old Aggregate
+        // (which also filters by type after the page is computed). The surviving page is identical.
+        val bareLink = FollowLink(boardCond, LinkDirection.IN, "OnBoard")
+        val sliced = bareLink.then(Skip(1))   // Slice(bareLink, Skip(1))
+        val result = allOf("Issue").intersect(sliced)
+        assertThat(result).isNotInstanceOf(GremlinQuery.Aggregate::class.java)
+        assertThat(result.toGremlin()).isEqualTo(
+            """g.V().has("name","b").hasLabel("Board").in("OnBoard_link").skip(1L).hasLabel("Issue")"""
+        )
+    }
+
+    @Test
+    fun `O21 - allOf(T) does not pre-empt O_B for Aggregate intersect allOf`() {
+        // O21 is placed after O_B precisely so O_B wins here: O_B recognises that the Aggregate's
+        // left branch is already labeled T and drops the redundant hasLabel entirely, rather than
+        // O21 appending an AndThen(Aggregate, hasLabel). Guards the placement-after-O_B invariant.
+        val aggr = issueCondition("status", "open")
+            .intersect(Labeled(GremlinQuery.Where.of(PropEqual("key", "ENG")), "Project"))
+        assertThat(aggr).isInstanceOf(GremlinQuery.Aggregate::class.java)
+
+        // Both orders resolve to the bare Aggregate, not an O21 rewrite.
+        assertThat(aggr.intersect(allOf("Issue"))).isEqualTo(aggr)
+        assertThat(allOf("Issue").intersect(aggr)).isEqualTo(aggr)
+    }
+
+    // --- O21 correctness investigation: OR-collapse (concern #1) and per-step safety (concern #2) ---
+
+    @Test
+    fun `O21 - allOf(T) intersect FollowLink of a DIFFERENT label stays Aggregate`() {
+        // Concern #1, the OR-collapse hazard: hasLabel(U).hasLabel(T) on consecutive steps is merged
+        // by InlineFilterStrategy into one multi-predicate HasStep that YTDBHasLabelStep evaluates as
+        // OR (the O19 defect). O21 must never create that shape. The label-mismatch guard above O21
+        // ensures it: when the other operand has a non-null label U != T, combineEfficient returns
+        // null *before* O21 → Aggregate, so no hasLabel(T) is appended onto an operand ending in
+        // hasLabel(U). Verified both orders.
+        val projectsLink = Labeled(FollowLink(boardCond, LinkDirection.IN, "OnBoard"), "Project")
+        assertThat(allOf("Issue").intersect(projectsLink)).isInstanceOf(GremlinQuery.Aggregate::class.java)
+        assertThat(projectsLink.intersect(allOf("Issue"))).isInstanceOf(GremlinQuery.Aggregate::class.java)
+    }
+
+    @Test
+    fun `O21 - no rewrite ever emits two consecutive hasLabel steps`() {
+        // Concern #1, structural proof: across every O21-eligible shape, the appended hasLabel(T) is
+        // either flattened (operand already labeled T) or separated from any pre-existing distinct
+        // hasLabel by a link / skip / where step. So the merge-able `hasLabel(A).hasLabel(B)` adjacency
+        // is never produced. GroovyTranslator renders bytecode pre-strategy, so adjacency (if any)
+        // would appear literally in the script.
+        val adjacentHasLabel = Regex("""hasLabel\([^)]*\)\.hasLabel\(""")
+        val ids = ByIds(listOf(RID.of(40, 1)))
+        val rewrites = listOf(
+            allOf("Issue").intersect(FollowLink(boardCond, LinkDirection.IN, "OnBoard")),  // bare FL
+            FollowLink(boardCond, LinkDirection.OUT, "viewers").intersect(allOf("Issue")),  // symmetric
+            allOf("Issue").intersect(issuesOnBoard),                                         // operand already labeled Issue (flattens)
+            allOf("Issue").intersect(FollowLink(ids, LinkDirection.OUT, "viewers")),         // production shape
+            allOf("Issue").intersect(FollowLink(boardCond, LinkDirection.IN, "OnBoard").then(Skip(1))), // Slice
+        )
+        rewrites.forEach { q ->
+            assertWithMessage("rewrite produced consecutive hasLabel: %s", q.toGremlin())
+                .that(adjacentHasLabel.containsMatchIn(q.toGremlin())).isFalse()
+        }
     }
 }


### PR DESCRIPTION
## What

[XD-1279](https://youtrack.jetbrains.com/issue/XD-1279). Intersecting *"all vertices of type T"* — `Labeled(Where(All), T)` — with another query `Q` previously fell back to the generic `Aggregate { P.within }` whenever `Q` had no extractable condition (FollowLink, Aggregate, UnionAll, Slice, Order). That Aggregate drives the traversal from a **full scan of every T vertex** and filters it by membership in the folded `Q` set — so a type filter on a usually-small `Q` runs as a scan of the entire extent of `T`.

This adds rule **O21** in `GremlinQueryOptimizer.combineEfficient`, exploiting:

```
allOf(T) ∩ Q  ≡  { x ∈ Q : isInstanceOf(x, T) }  =  Q.then(HasLabel(T))
Where(All) ∩ Q ≡ Q                                  // untyped All ⇒ pure identity
```

The intersection now keeps `Q` as the driving traversal and reduces the type check to a single inline `hasLabel(T)`.

## Scope / guards

O21 fires **only** when one operand's `extractCondition` is `All` **and** the other operand has **no** extractable condition — i.e. exactly the cases that would otherwise hit `Aggregate`. Operands that already have an extractable condition (`ByIds`, `Labeled(Where)`, `allOf` itself) are left to the existing bottom condition-combiner unchanged.

**Placement:** after `O_B` (which drops the redundant `hasLabel` entirely for `Aggregate ∩ allOf`) and before `O7`/`O16`/`O20` (which deliberately skip or mishandle an `All` condBlock).

## Correctness

- **No OR-collapse:** the existing label-mismatch guard ensures `Q`'s label is `null` or `== T` when O21 fires, so `Q.then(HasLabel(T))` flattens via `Labeled.of` rather than producing a double-label `Labeled(Labeled(_, U), T)` — the consecutive-`hasLabel` shape that `YTDBHasLabelStep` mis-evaluates as OR (the O19 hazard). Mismatched typed operands stay at `Aggregate`.
- **Per-step safety matrix** established for every operand shape O21 can fire on (FollowLink / AndThen / UnionAll / Slice / Order / Aggregate); each appends `hasLabel` after a non-Has terminal step. `SortBy` is stripped by O3 and `Order(Dedup)` by O17 upstream.
- **Paging set-identity:** for `Slice`/`Order`, both O21 and the old Aggregate apply the type filter *after* the page/sort is computed, so the surviving set is identical (O21 additionally preserves the operand's order).

## Tests

`GremlinQueryTest` / `GremlinQueryCombineMatrixTest`:
- `allOf ∩ FollowLink` both orders (incl. bare FollowLink and the `ByIds`/OUT production shape), `Where(All)` identity, `allOf ∩ allOf`, and `allOf ∩ condition` left to the generic combiner.
- Correctness investigation: mismatched-label operand stays `Aggregate`; no rewrite emits consecutive `hasLabel` steps; `Slice` applies the type filter after the page; O21 does not pre-empt `O_B`.

Full `./gradlew build` green.