### PR TITLE
XD-1280 Direct by-id loads: route ByIds through g.V(ids), drop hasId class scans

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityId.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityId.kt
@@ -61,6 +61,8 @@ class RIDEntityId(
 
     override fun getTypeName(): String = schemaClassName ?: "typeNotFound"
 
+    override fun getTypeNameOrNull(): String? = schemaClassName
+
     // (typeId, localId) identity, compared against any EntityId regardless of concrete class. The
     // hash and ordering formulas mirror PersistentEntityId's (the only other EntityId impl) so the
     // two stay interchangeable — kept honest by EntityIdContractTest. The 32-bit shift on the int

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntityId.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntityId.kt
@@ -22,4 +22,23 @@ interface YTDBEntityId : EntityId {
     fun asOId(): RID
 
     fun getTypeName(): String
+
+    /** The resolved schema class name, or `null` if it isn't known. Unlike [getTypeName] this never
+     *  returns a sentinel — callers that need a real class (e.g. to scope a query to `FROM <class>`)
+     *  must skip scoping when it is `null`. */
+    fun getTypeNameOrNull(): String?
 }
+
+/**
+ * The entity's schema class name, for scoping a by-id query to `FROM <class>` instead of `FROM V`:
+ * the class carried by the id, or — only if that is absent — the authoritative `typeId -> class`
+ * lookup, which is always resolvable for a live type. Returns `null` only if even that fails (e.g.
+ * the type was removed), in which case callers skip scoping. The [getType] lookup runs only on the
+ * (rare) miss, so the common path stays allocation-free.
+ */
+fun YTDBEntityId.resolveTypeName(tx: YTDBStoreTransaction): String? =
+    getTypeNameOrNull() ?: runCatching { tx.getType(typeId) }.getOrNull()
+
+/** [resolveTypeName] resolving the transaction from [store]'s active transaction. */
+fun YTDBEntityId.resolveTypeName(store: YTDBEntityStore): String? =
+    getTypeNameOrNull() ?: runCatching { store.requireActiveTransaction().getType(typeId) }.getOrNull()

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
@@ -376,7 +376,7 @@ class YTDBStoreTransactionImpl(
         return YTDBEntityIterable.query(
             getStore(),
             GremlinQuery
-                .ByIds(listOf(entityId.asOId()))
+                .ByIds(listOf(entityId.asOId()), entityId.resolveTypeName(this))
                 .then(GremlinBlock.InLink(linkName))
                 .then(GremlinBlock.HasLabel(entityType)),
             polymorphic
@@ -401,7 +401,7 @@ class YTDBStoreTransactionImpl(
         return YTDBEntityIterable.query(
             getStore(),
             GremlinQuery
-                .ByIds(listOf((entity.id as YTDBEntityId).asOId()))
+                .ByIds(listOf((entity.id as YTDBEntityId).asOId()), (entity.id as YTDBEntityId).resolveTypeName(this))
                 .then(GremlinBlock.InLink(linkName)),
             polymorphic
         )

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
@@ -492,7 +492,7 @@ open class YTDBVertexEntity(
                 tx.getStore(),
                 linkNames.asSequence()
                     .map { ln ->
-                        GremlinQuery.ByIds(listOf(this.oEntityId.asOId()))
+                        GremlinQuery.ByIds(listOf(this.oEntityId.asOId()), this.oEntityId.resolveTypeName(tx))
                             .then(GremlinBlock.OutLink(ln))
                     }
                     .reduce { acc, it -> acc.union(it) }

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinBlock.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinBlock.kt
@@ -422,15 +422,6 @@ sealed class GremlinBlock(val shortName: String, val type: BlockType, val isChai
 
     }
 
-    data class IdEqual(val rid: RID) : GremlinBlock("ide", BlockType.CONDITION) {
-        override fun traverse(g: YT): YT =
-            g.hasId(rid)
-
-        override fun describe(s: StringBuilder): StringBuilder =
-            s.append("id=").append(rid)
-
-    }
-
     data class IdWithin(val within: Collection<RID>) : GremlinBlock("idw", BlockType.CONDITION, isChainable = true) {
         override fun traverse(g: YT): YT = g.hasId(P.within(within))
 

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
@@ -54,7 +54,12 @@ sealed class GremlinQuery {
 
         else -> when (this) {
             is Where -> Where(this.block.andThen(block))
-            is ByIds -> Where(this.asBlock().andThen(block))
+            // Wrap (don't collapse): AndThen routes through ByIds.startTraversal/continueTraversal, so
+            // the chained block lands on the direct `V(ids)` load. Collapsing to
+            // `Where(IdWithin.andThen(block))` would instead emit `V().hasId(within).<block>` — a full
+            // vertex scan, defeating the by-id direct access. (asBlock()=IdWithin is still used by the
+            // set combiners; only this chaining path must avoid it.)
+            is ByIds -> AndThen(this, block)
             is Labeled -> Labeled(this.inner.then(block), this.label)
             is AndThen -> AndThen(this.inner, this.block.andThen(block))
             else -> AndThen(this, block)
@@ -177,12 +182,28 @@ sealed class GremlinQuery {
 
     // todo: think how to preserve the order of the parameters
     // todo: handle Take & Skip differently too
-    data class ByIds(val ids: List<RID>) : Condition(GremlinBlock.IdWithin(ids)) {
+    // [entityType], when known, is the schema class the ids belong to. It does not change which
+    // records match (an id already identifies exactly one record); it lets the query target
+    // `FROM <entityType>` instead of `FROM V`. This matters in non-start positions (e.g. inside a
+    // union, built via [continueTraversal]) where we can't use the direct `gs.V(ids)` form and would
+    // otherwise emit `g.V().hasId(within)` → a full scan of every vertex.
+    data class ByIds(val ids: List<RID>, val entityType: String? = null) : Condition(GremlinBlock.IdWithin(ids)) {
+        // Direct by-id access: both positions use `V(ids)` (the ids go on the GraphStep → YTDB's
+        // getElementsByIds, an O(1) positional load per id), NOT `V().hasId(...)` which the SQL
+        // planner runs as `FETCH FROM CLASS` (a scan of the whole class extent + filter). [entityType],
+        // when known, is kept only as a cheap residual label filter — the direct branch still applies
+        // any remaining HasContainers — it no longer affects whether a scan happens.
         // gs.V() with no IDs traverses every vertex — wrong for an empty by-IDs query
         // (which can arise from optimiser reductions like ByIds(x).difference(ByIds(x))).
         override fun startTraversal(gs: GraphTraversalSource): YTBuilder =
             if (ids.isEmpty()) YTBuilder.of(gs.V(), GremlinBlock.None)
             else YTBuilder(gs.V(*ids.toTypedArray()).asYT(), 0)
+                .let { if (entityType != null) it.combine(GremlinBlock.HasLabel(entityType)) else it }
+
+        override fun continueTraversal(t: YT, paramCounter: Int, ignoreSort: Boolean): YTBuilder =
+            if (ids.isEmpty()) YTBuilder.of(t.V(), GremlinBlock.None, paramCounter)
+            else YTBuilder(t.V(*ids.toTypedArray()).asYT(), paramCounter)
+                .let { if (entityType != null) it.combine(GremlinBlock.HasLabel(entityType)) else it }
     }
 
     data class NestedCondition(val structure: List<String>, val condition: Condition) : Condition(

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQueryShape.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQueryShape.kt
@@ -126,7 +126,6 @@ object GremlinQueryShape {
             is GremlinBlock.MatchStringProp -> append("MatchStringProp(\"${block.property}\", ${block.op}, ?, ?, ?)")
             is GremlinBlock.OutLink       -> append("OutLink(\"${block.linkName}\")")
             is GremlinBlock.InLink        -> append("InLink(\"${block.linkName}\")")
-            is GremlinBlock.IdEqual       -> append("IdEqual(?)")
             is GremlinBlock.IdWithin      -> append("IdWithin(?)")
             is GremlinBlock.Limit         -> append("Limit(?)")
             is GremlinBlock.Skip          -> append("Skip(?)")

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
@@ -29,6 +29,7 @@ import jetbrains.exodus.entitystore.util.unsupported
 import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityId
 import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityStore
 import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
+import jetbrains.exodus.entitystore.youtrackdb.resolveTypeName
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
@@ -63,11 +64,13 @@ interface YTDBEntityIterable : EntityIterable {
         fun empty() = EMPTY
 
         @JvmStatic
-        fun single(store: YTDBEntityStore, entityId: EntityId) = query(
-            store,
-            GremlinQuery.all
-                .then(GremlinBlock.IdEqual((entityId as YTDBEntityId).asOId()))
-        )
+        fun single(store: YTDBEntityStore, entityId: EntityId): YTDBEntityIterable {
+            val ytdbId = entityId as YTDBEntityId
+            // Direct by-id access: `g.V(rid)` (id on the GraphStep → getElementsByIds, O(1) positional
+            // load) instead of `g.V().hasId(rid)`, which the planner runs as a class scan. The resolved
+            // type is kept only as a residual label filter.
+            return query(store, GremlinQuery.ByIds(listOf(ytdbId.asOId()), ytdbId.resolveTypeName(store)))
+        }
 
         val EMPTY = object : YTDBEntityIterable {
 

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBVertexEntityIterable.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBVertexEntityIterable.kt
@@ -26,6 +26,7 @@ import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityId
 import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityStore
 import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
 import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity
+import jetbrains.exodus.entitystore.youtrackdb.resolveTypeName
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
 import org.apache.commons.collections4.IterableUtils
@@ -123,7 +124,7 @@ class YTDBVertexEntityIterable(
 
     private fun asQueryIterable() = YTDBEntityIterable.query(
         tx.getStore(),
-        GremlinQuery.ByIds(listOf(targetEntityID.asOId()))
+        GremlinQuery.ByIds(listOf(targetEntityID.asOId()), targetEntityID.resolveTypeName(tx))
             .then(GremlinBlock.OutLink(linkName))
     )
 }

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
@@ -276,7 +276,7 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
             ) as YTDBEntityIterable
 
             // Then
-            checkGremlinPattern(issues, """g.V({rid}).in("OnBoard_link").hasLabel("Issue")""")
+            checkGremlinPattern(issues, """g.V({rid}).hasLabel("Board").in("OnBoard_link").hasLabel("Issue")""")
             assertNamesExactly(issues, "issue1", "issue2")
         }
     }
@@ -299,10 +299,10 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
             val concat = issuesOnBoard1.concat(issuesOnBoard2)
 
             // Then
-            // concat produces UnionAll([board1_query, board2_query]); each ByIds uses P.within in continueTraversal
+            // concat produces UnionAll([board1_query, board2_query]); each ByIds uses direct V(ids) in continueTraversal
             checkGremlinPattern(
                 concat as YTDBEntityIterable,
-                """g.union(__.V().hasId(P.within([{rid}])).in("OnBoard_link").hasLabel("Issue"),__.V().hasId(P.within([{rid}])).in("OnBoard_link").hasLabel("Issue"))"""
+                """g.union(__.V({rid}).hasLabel("Board").in("OnBoard_link").hasLabel("Issue"),__.V({rid}).hasLabel("Board").in("OnBoard_link").hasLabel("Issue"))"""
             )
             // Link traversal order is not guaranteed — use unordered check
             assertNamesExactly(concat, "issue1", "issue2", "issue1")
@@ -548,11 +548,11 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
 
             // Then
             // Falls back to Aggregate: right (board2) collected first, then left (board1) filtered against it.
-            // right.startTraversal → g.V(rid_board2).in(...).hasLabel("Issue")
-            // left.continueTraversal → .V().hasId(P.within([rid_board1])).in(...).hasLabel("Issue")
+            // right.startTraversal → g.V(rid_board2).hasLabel("Board").in(...).hasLabel("Issue")
+            // left.continueTraversal → .V(rid_board1).hasLabel("Board").in(...).hasLabel("Issue")  (direct by-id)
             checkGremlinPattern(
                 issues as YTDBEntityIterable,
-                """g.V({rid}).in("OnBoard_link").hasLabel("Issue").aggregate("aggr_0").fold().V().hasId(P.within([{rid}])).in("OnBoard_link").hasLabel("Issue").where(P.without(["aggr_0"]))"""
+                """g.V({rid}).hasLabel("Board").in("OnBoard_link").hasLabel("Issue").aggregate("aggr_0").fold().V({rid}).hasLabel("Board").in("OnBoard_link").hasLabel("Issue").where(P.without(["aggr_0"]))"""
             )
             assertNamesExactly(issues, "issue2", "issue3")
         }

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/GremlinQueryTest.kt
@@ -196,15 +196,49 @@ class GremlinQueryTest {
     }
 
     @Test
-    fun `IdEqual produces hasId`() {
-        assertThat(IdEqual(RID.of(34, 4)).toGremlin())
-            .isEqualTo("__.hasId(#34:4)")
-    }
-
-    @Test
     fun `IdWithin produces hasId with within predicate`() {
         assertThat(IdWithin(listOf(RID.of(34, 4), RID.of(34, 5))).toGremlin())
             .isEqualTo("__.hasId(P.within([#34:4, #34:5]))")
+    }
+
+    @Test
+    fun `ByIds builds direct g_V(ids), never a hasId class scan`() {
+        // By-id lookups must put the ids ON the GraphStep (g.V(ids) → YTDB getElementsByIds, an O(1)
+        // positional load), NOT g.V().hasId(...) which the planner runs as a FETCH FROM CLASS scan.
+        val gremlin = ByIds(listOf(RID.of(34, 4), RID.of(34, 5))).toGremlin()
+        assertThat(gremlin).isEqualTo("g.V(#34:4,#34:5)")
+        assertThat(gremlin).doesNotContain("hasId")
+    }
+
+    @Test
+    fun `ByIds with entityType keeps direct g_V(ids) plus a residual hasLabel`() {
+        // entityType is only a residual class filter on the direct-load path; it must NOT turn the
+        // query back into a hasId scan.
+        val gremlin = ByIds(listOf(RID.of(34, 4)), "Issue").toGremlin()
+        assertThat(gremlin).isEqualTo("""g.V(#34:4).hasLabel("Issue")""")
+        assertThat(gremlin).doesNotContain("hasId")
+    }
+
+    @Test
+    fun `ByIds over a transient (negative-position) RID still builds direct g_V(id)`() {
+        // New/transient entities have a negative cluster position (e.g. #165:-3). The direct
+        // getElementsByIds branch loads these from the in-tx record set, so the by-id form must hold
+        // for negative RIDs exactly as for committed ones — no hasId fallback.
+        val gremlin = ByIds(listOf(RID.of(165, -3))).toGremlin()
+        assertThat(gremlin).isEqualTo("g.V(#165:-3)")
+        assertThat(gremlin).doesNotContain("hasId")
+    }
+
+    @Test
+    fun `ByIds then a property condition keeps direct g_V(ids), not a hasId scan`() {
+        // Chaining a non-special block onto a ByIds must stay on the direct-load path. Collapsing it
+        // to Where(IdWithin.andThen(...)) would emit g.V().hasId(within(...)).has(...) — a full vertex
+        // scan filtered by id — which is exactly what by-id access exists to avoid.
+        val gremlin = ByIds(listOf(RID.of(34, 4), RID.of(34, 5)))
+            .then(PropEqual("name", "a"))
+            .toGremlin()
+        assertThat(gremlin).isEqualTo("""g.V(#34:4,#34:5).has("name","a")""")
+        assertThat(gremlin).doesNotContain("hasId")
     }
 
     @Test

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/QueryEngine.kt
@@ -22,6 +22,7 @@ import jetbrains.exodus.entitystore.StoreTransaction
 import jetbrains.exodus.entitystore.iterate.EntityIdSet
 import jetbrains.exodus.entitystore.util.EntityIdSetFactory
 import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityId
+import jetbrains.exodus.entitystore.youtrackdb.resolveTypeName
 import jetbrains.exodus.entitystore.youtrackdb.YTDBEntityStore
 import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
@@ -281,7 +282,10 @@ open class QueryEngine(val modelMetaData: ModelMetaData?, val persistentStore: P
     open fun wrap(entity: Entity): Iterable<Entity> {
         return YTDBEntityIterable.query(
             oStore,
-            GremlinQuery.ByIds(listOf((entity.id as YTDBEntityId).asOId()))
+            GremlinQuery.ByIds(
+                listOf((entity.id as YTDBEntityId).asOId()),
+                (entity.id as YTDBEntityId).resolveTypeName(oStore)
+            )
         )
         // xodus original code
         // return SingleEntityIterable(persistentStore.andCheckCurrentTransaction, entity.id)

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToManyLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdManyToManyLink.kt
@@ -32,6 +32,7 @@ import kotlinx.dnq.store.XdQueryEngine
 import kotlinx.dnq.util.isReadOnly
 import kotlinx.dnq.util.reattach
 import kotlinx.dnq.util.threadSessionOrThrow
+import kotlinx.dnq.util.xdEntityTypeName
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 
@@ -68,8 +69,10 @@ open class XdManyToManyLink<R : XdEntity, T : XdEntity>(
 
                                 YTDBEntityIterable.query(
                                     session.getStore(),
-                                    GremlinQuery.all
-                                        .then(GremlinBlock.IdEqual((thisRef.entityId as YTDBEntityId).asOId()))
+                                    GremlinQuery.ByIds(
+                                        listOf((thisRef.entityId as YTDBEntityId).asOId()),
+                                        thisRef.xdEntityTypeName
+                                    )
                                         .then(GremlinBlock.InLink(oppositeField.oppositeDbName))
                                         .then(GremlinBlock.HasLabel(oppositeType))
                                 )

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToManyLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdOneToManyLink.kt
@@ -31,6 +31,7 @@ import kotlinx.dnq.store.XdQueryEngine
 import kotlinx.dnq.util.isReadOnly
 import kotlinx.dnq.util.reattach
 import kotlinx.dnq.util.threadSessionOrThrow
+import kotlinx.dnq.util.xdEntityTypeName
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 
@@ -65,8 +66,10 @@ open class XdOneToManyLink<R : XdEntity, T : XdEntity>(
                             queryEngine.wrap(
                                 YTDBEntityIterable.query(
                                     (thisRef.threadSessionOrThrow.transactionInternal as YTDBStoreTransaction).getStore(),
-                                    GremlinQuery.all
-                                        .then(GremlinBlock.IdEqual((thisRef.entityId as YTDBEntityId).asOId()))
+                                    GremlinQuery.ByIds(
+                                        listOf((thisRef.entityId as YTDBEntityId).asOId()),
+                                        thisRef.xdEntityTypeName
+                                    )
                                         .then(GremlinBlock.InLink(oppositeField.oppositeDbName))
                                         .then(GremlinBlock.HasLabel(oppositeType))
                                 )

--- a/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToManyChildrenLink.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/link/XdParentToManyChildrenLink.kt
@@ -30,6 +30,7 @@ import kotlinx.dnq.query.isNotEmpty
 import kotlinx.dnq.util.isReadOnly
 import kotlinx.dnq.util.reattach
 import kotlinx.dnq.util.threadSessionOrThrow
+import kotlinx.dnq.util.xdEntityTypeName
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 
@@ -63,8 +64,10 @@ open class XdParentToManyChildrenLink<R : XdEntity, T : XdEntity>(
                             session.createPersistentEntityIterableWrapper(
                                 YTDBEntityIterable.query(
                                     (session.transactionInternal as YTDBStoreTransaction).getStore(),
-                                    GremlinQuery.all
-                                        .then(GremlinBlock.IdEqual((thisRef.entityId as YTDBEntityId).asOId()))
+                                    GremlinQuery.ByIds(
+                                        listOf((thisRef.entityId as YTDBEntityId).asOId()),
+                                        thisRef.xdEntityTypeName
+                                    )
                                         .then(GremlinBlock.InLink(oppositeField.oppositeDbName))
                                         .then(GremlinBlock.HasLabel(oppositeType))
                                 )

--- a/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/query/XdQuery.kt
@@ -275,6 +275,11 @@ fun <T : XdEntity> XdEntityType<T>.queryOf(vararg elements: T?): XdQuery<T> {
             txn.store,
             YTDBEntityIterable.query(
                 (txn.transactionInternal as YTDBStoreTransaction).getStore(),
+                // No entityType scoping: the elements may be *subtypes* of this XdEntityType (e.g.
+                // UserBase.queryOf(user) where user is a User), and the residual hasLabel is an exact,
+                // non-polymorphic match — scoping to the declared supertype would drop every subtype
+                // row. The ids go on the GraphStep (g.V(ids) → direct getElementsByIds), so there is no
+                // FROM-V scan to avoid here regardless of label.
                 GremlinQuery.ByIds(
                     notNullElements.map { txn.newEntity(it.entity).entity.id.asOId() }
                 )

--- a/dnq/src/main/kotlin/kotlinx/dnq/store/XdQueryEngine.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/store/XdQueryEngine.kt
@@ -26,6 +26,7 @@ import jetbrains.exodus.entitystore.EntityIterable
 import jetbrains.exodus.entitystore.StoreTransaction
 import jetbrains.exodus.entitystore.asYTDBTransaction
 import jetbrains.exodus.entitystore.youtrackdb.YTDBPersistentEntityStore
+import jetbrains.exodus.entitystore.youtrackdb.resolveTypeName
 import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBEntityIterable
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
 import jetbrains.exodus.query.InMemoryEntityIterable
@@ -113,7 +114,10 @@ class XdQueryEngine(val store: TransientEntityStore) :
             ?.let {
                 YTDBEntityIterable.query(
                     session.transactionInternal.asYTDBTransaction().getStore(),
-                    GremlinQuery.ByIds(listOf(it.entity.id.asOId()))
+                    GremlinQuery.ByIds(
+                        listOf(it.entity.id.asOId()),
+                        it.entity.id.resolveTypeName(session.transactionInternal.asYTDBTransaction())
+                    )
                 )
             } ?: throw IllegalArgumentException()
     }

--- a/dnq/src/main/kotlin/kotlinx/dnq/util/ReflectionUtil.kt
+++ b/dnq/src/main/kotlin/kotlinx/dnq/util/ReflectionUtil.kt
@@ -243,3 +243,12 @@ val <T : XdEntity> KClass<T>.entityType: XdEntityType<T>
         companionObjectInstance as? XdEntityType<T>
                 ?: throw IllegalArgumentException("XdEntity contract is broken for $java, its companion object is not an instance of XdEntityType")
     } as XdEntityType<T>
+
+/**
+ * The Xd model type name of this entity's concrete class. Resolved from the Kotlin class via the
+ * model (cached), so it is always available and never the "typeNotFound" sentinel that
+ * [jetbrains.exodus.entitystore.Entity.getType] can return when an id's schema class is unresolved.
+ * Safe to use to scope a query to `FROM <class>`.
+ */
+val XdEntity.xdEntityTypeName: String
+    get() = javaClass.entityType.entityType

--- a/dnq/src/test/kotlin/kotlinx/dnq/ReflectionUtilTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/ReflectionUtilTest.kt
@@ -22,6 +22,7 @@ import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity
 import kotlinx.dnq.query.eq
 import kotlinx.dnq.query.single
 import kotlinx.dnq.util.isDefined
+import kotlinx.dnq.util.xdEntityTypeName
 import org.junit.Ignore
 import org.junit.Test
 
@@ -104,6 +105,22 @@ class ReflectionUtilTest : DBTest() {
             assertThat(nestedGroup.isDefined(NestedGroup::owner)).isTrue()
         }
 
+    }
+
+    @Test
+    fun `xdEntityTypeName resolves an entity's concrete model type`() {
+        store.transactional {
+            // Resolved from the Kotlin class via the model — used to scope by-id queries; must equal
+            // the companion's entityType and never the "typeNotFound" sentinel.
+            val user = User.new { login = "u"; skill = 1 }
+            assertThat(user.xdEntityTypeName).isEqualTo(User.entityType)
+
+            // A subclass instance resolves to its own concrete type, not the parent's. RootGroup is
+            // a Group subtype with no required links, so it's valid to create standalone here.
+            val root = RootGroup.new { name = "root" }
+            assertThat(root.xdEntityTypeName).isEqualTo(RootGroup.entityType)
+            assertThat(root.xdEntityTypeName).isNotEqualTo(Group.entityType)
+        }
     }
 
     private fun <T : XdEntity> TransientStoreSession.createPersistentEntity(entityType: XdEntityType<T>, init: YTDBVertexEntity.() -> Unit) {


### PR DESCRIPTION
By-id lookups previously compiled to `g.V().hasId(rid)`, which the YTDB SQL planner runs as a FETCH FROM CLASS (full class-extent scan + filter). This PR puts the ids on the GraphStep instead so they take `YTDBGraphStep`'s `getElementsByIds` branch (an O(1) positional load), eliminating those scans.

## Changes
- **`GremlinQuery.ByIds`**: use `V(ids)` directly in both `startTraversal` and `continueTraversal` (the latter is new — fixes the union/mid-traversal path that previously fell back to a `t.V().hasId(within)` scan).
- **`then(ByIds, block)`** now builds `AndThen(this, block)` so chaining a condition stays on the direct-load path instead of collapsing to `Where(IdWithin...)`.
- Removed the now-dead `GremlinBlock.IdEqual` (and its shape rendering); `single()` and the by-id call sites construct `ByIds`.
- Added type resolution to scope by-id queries to their concrete class: `YTDBEntityId.resolveTypeName/getTypeNameOrNull` (schema-id fast path, never the typeNotFound sentinel) and `XdEntity.xdEntityTypeName` (cached model lookup). Applied at `single`/`getLinks`/`findLinks`/`wrap` and the three link delegates.
- `queryOf` no longer scopes to the declared `XdEntityType`: its elements may be subtypes (e.g. `UserBase.queryOf(user)`), and an exact, non-polymorphic `hasLabel` on a supertype would drop every subtype row. The direct `V(ids)` load needs no label to avoid a scan.

## Tests
- `GremlinQueryTest` (direct `g.V(ids)`, transient/negative-RID, then-condition no scan)
- updated `YTDBGremlinEntityIterableTest` shape assertions
- `ReflectionUtilTest` for `xdEntityTypeName`
- Full build green against published YTDB 0.5.0-dev nightly.