### PR TITLE
XD-1284 restore transactional(readonly=true) semantics in the YTDB-based DNQ fork

### DIFF
--- a/dnq-entity-store/build.gradle.kts
+++ b/dnq-entity-store/build.gradle.kts
@@ -1,4 +1,4 @@
-val ytdbVersion = "0.5.0-20260707.235507-4dabb80-dev-SNAPSHOT"
+val ytdbVersion = "0.5.0-20260728.151351-0901b02-dev-SNAPSHOT"
 
 val ktorVersion = "3.1.3"
 val graalVmVersion = "22.0.0.2"

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreExt.kt
@@ -23,17 +23,26 @@ import mu.KLogging
 internal object TransientEntityStoreExt : KLogging() {
     fun <T> transactional(
         store: TransientEntityStore,
+        readonly: Boolean = false,
         isNew: Boolean = false,
         queryCancellingPolicy: QueryCancellingPolicy? = null,
         block: (TransientStoreSession) -> T
     ): T {
         val currentSession = store.threadSession
         return when {
-            currentSession == null -> startNewAndRun(store, queryCancellingPolicy, block)
-            isNew -> suspendAndRun(store, queryCancellingPolicy, block)
+            currentSession == null -> startNewAndRun(store, readonly, queryCancellingPolicy, block)
+            isNew || currentSession.requestedReadonly != readonly ->
+                suspendAndRun(store, readonly, queryCancellingPolicy, block)
             else -> block(currentSession)
         }
     }
+
+    /**
+     * The readonly-ness the session was requested with, as opposed to [TransientStoreSession.isReadonly],
+     * which also flips to `true` when a session becomes quiescent after `flush()`/`revert()`.
+     */
+    private val TransientStoreSession.requestedReadonly: Boolean
+        get() = (this as? TransientSessionImpl)?.requestedReadonly ?: this.isReadonly
 
     /**
      * Runs [block] in a new independent transaction while an outer transaction is active on the current thread.
@@ -46,12 +55,13 @@ internal object TransientEntityStoreExt : KLogging() {
      */
     private fun <T> suspendAndRun(
         store: TransientEntityStore,
+        readonly: Boolean,
         queryCancellingPolicy: QueryCancellingPolicy?,
         block: (TransientStoreSession) -> T
     ): T {
         return store.withSuspendedSession {
             store.persistentStore.withSuspendedTransaction {
-                startNewAndRun(store, queryCancellingPolicy, block)
+                startNewAndRun(store, readonly, queryCancellingPolicy, block)
             }
         }
     }
@@ -62,11 +72,12 @@ internal object TransientEntityStoreExt : KLogging() {
      */
     private fun <T> startNewAndRun(
         store: TransientEntityStore,
+        readonly: Boolean,
         queryCancellingPolicy: QueryCancellingPolicy?,
         block: (TransientStoreSession) -> T
     ): T {
         try {
-            val newSession = store.beginSession(queryCancellingPolicy)
+            val newSession = store.beginSession(readonly, queryCancellingPolicy)
             var wasEx = true
             try {
                 val result = block(newSession)
@@ -88,9 +99,14 @@ internal object TransientEntityStoreExt : KLogging() {
     }
 
     private fun TransientEntityStore.beginSession(
+        readonly: Boolean,
         queryCancellingPolicy: QueryCancellingPolicy?
     ): TransientStoreSession {
-        val transaction = this.beginSession()
+        val transaction = if (readonly) {
+            this.beginReadonlyTransaction()
+        } else {
+            this.beginSession()
+        }
         return try {
             // Exception could be thrown due to race condition in inited ServiceLocator
             if (queryCancellingPolicy != null) {

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityStoreImpl.kt
@@ -91,7 +91,7 @@ open class TransientEntityStoreImpl : TransientEntityStore {
         queryCancellingPolicy: QueryCancellingPolicy?,
         block: (TransientStoreSession) -> T
     ): T = TransientEntityStoreExt.transactional(
-        this, isNew, queryCancellingPolicy, block
+        this, readonly, isNew, queryCancellingPolicy, block
     )
 
     override fun beginTransaction(): StoreTransaction {
@@ -103,6 +103,22 @@ open class TransientEntityStoreImpl : TransientEntityStore {
     }
 
     override fun beginReadonlyTransaction(): TransientStoreSession {
+        assertOpen()
+
+        logger.debug { "Begin new readonly session" }
+
+        val currentSession = this.currentSession.get()
+        if (currentSession != null) {
+            if ((currentSession as? TransientSessionImpl)?.requestedReadonly == true) {
+                logger.debug { "Return readonly session already associated with the current thread $currentSession" }
+                return currentSession
+            }
+            // never hand out a writable session to a readonly request
+            throw IllegalStateException(
+                "A non-readonly session is already associated with the current thread: $currentSession"
+            )
+        }
+
         return registerStoreSession(TransientSessionImpl(this, readonly = true))
     }
 

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientSessionImpl.kt
@@ -41,9 +41,31 @@ internal const val PARENT_TO_CHILD_LINK_NAME = "__PARENT_TO_CHILD_LINK_NAME__"
 
 class TransientSessionImpl(
     private val store: TransientEntityStoreImpl,
-    private var readonly: Boolean,
+    readonly: Boolean,
 ) : TransientStoreSession, SessionQueryMixin {
     companion object : KLogging()
+
+    /**
+     * Whether this session was explicitly requested as readonly — the caller's contract.
+     *
+     * Immutable, unlike the lifecycle-state [readonly] flag. Requested-readonly sessions
+     * reject write attempts with [ReadonlyTransactionException] and keep their persistent
+     * transaction readonly.
+     */
+    val requestedReadonly: Boolean = readonly
+
+    /**
+     * Lifecycle state: whether the cheap read-only changes tracker is currently installed,
+     * i.e. the session is "quiescent" (writable tracker allocation is deferred until the
+     * first write). Starts as the constructor's requested value; flips to `false` on the
+     * first tracked write via [upgradeReadonlyTransactionIfNecessary] (tracker upgraded to
+     * writable); flips back to `true` after [flush]/[revert] (changes gone, read-only
+     * tracker reinstalled). NOT the caller's contract — see [requestedReadonly]: a plain
+     * writable session looks `readonly=true` right after a flush. Also NOT "no pending
+     * changes": a requested-readonly session can have queued changes (findOrNew
+     * found-branch) while this stays `true`. Backs the public [isReadonly].
+     */
+    private var readonly: Boolean = readonly
 
     init {
         if (store.modelMetaData?.entitiesMetaData?.firstOrNull() == null) {
@@ -77,7 +99,7 @@ class TransientSessionImpl(
         get() = state == State.Aborted
 
     override var transactionInternal: StoreTransaction =
-        this.store.persistentStore.beginTransaction()
+        beginPersistentTransaction()
         get() {
             assertOpen("get persistent transaction")
             return field
@@ -99,6 +121,18 @@ class TransientSessionImpl(
 
     private val persistentStore: PersistentEntityStore
         get() = store.persistentStore
+
+    /**
+     * Opens a new persistent transaction; readonly if this session was requested as readonly
+     * (defense-in-depth: YTDB's writable-transaction check backstops raw entity-layer writes
+     * that bypass DNQ change tracking).
+     */
+    private fun beginPersistentTransaction(): StoreTransaction =
+        if (requestedReadonly) {
+            store.persistentStore.beginReadonlyTransaction()
+        } else {
+            store.persistentStore.beginTransaction()
+        }
 
     private fun initChangesTracker(readonly: Boolean) {
         transientChangesTracker.dispose()
@@ -129,16 +163,14 @@ class TransientSessionImpl(
 
     internal fun upgradeReadonlyTransactionIfNecessary() {
         if (readonly) {
-            readonly = false
-            val persistentStore = persistentStore
-            //TODO this check was targeted to envConfig
-            if (persistentStore.currentTransaction?.isReadonly != true) {
-                upgradeHook?.run()
-//                persistentStore.registerTransaction(newTxn)
-                changesTracker = this.transientChangesTracker.upgrade()
-            } else {
+            // Throw before any state mutation so that catch-and-continue leaves the session
+            // consistent (no readonly=false flip, no changes-tracker swap on the throw path).
+            if (requestedReadonly || persistentStore.currentTransaction?.isReadonly == true) {
                 throw ReadonlyTransactionException()
             }
+            readonly = false
+            upgradeHook?.run()
+            changesTracker = this.transientChangesTracker.upgrade()
         }
     }
 
@@ -171,12 +203,10 @@ class TransientSessionImpl(
         logger.debug("Revert transient session {}", this)
         assertOpen("revert")
 
-        if (!transactionInternal.isReadonly) {
-            loadedIds = EntityIdSetFactory.newSet()
-            entitiesUpdater.clear()
-        }
+        loadedIds = EntityIdSetFactory.newSet()
+        entitiesUpdater.clear()
         closePersistentSession()
-        transactionInternal = this.store.persistentStore.beginTransaction()
+        transactionInternal = beginPersistentTransaction()
         this.readonly = true
         initChangesTracker(readonly = true)
     }
@@ -199,7 +229,7 @@ class TransientSessionImpl(
 
             val oldChangesTracker = transientChangesTracker
             closePersistentSession()
-            this.transactionInternal = this.store.persistentStore.beginTransaction()
+            this.transactionInternal = beginPersistentTransaction()
             this.changesTracker = ReadOnlyTransientChangesTrackerImpl()
             //all changes were already flushed
             this.readonly = true
@@ -240,8 +270,13 @@ class TransientSessionImpl(
                         replaying = true
                         logger.debug(nre) { "Replaying changes: ${nre.message}" }
 
+                        // Replay is a write path. A requested-readonly session must never reach it
+                        // (its flush is idempotent and returns before flushing); keep the invariant
+                        // explicit instead of silently opening a writable transaction.
+                        if (requestedReadonly) throw ReadonlyTransactionException()
+
                         // replay changes
-                        transactionInternal = this.store.persistentStore.beginTransaction()
+                        transactionInternal = beginPersistentTransaction()
                         transientChangesTracker.changedEntities.forEach {
                             it.resetIfNew()
                             it.generateIdIfNew()

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionalTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionalTest.kt
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq.concurrent.transaction
+
+import com.google.common.truth.Truth.assertThat
+import jetbrains.exodus.database.TransientStoreSession
+import jetbrains.exodus.env.ReadonlyTransactionException
+import kotlinx.dnq.DBTest
+import kotlinx.dnq.creator.findOrNew
+import kotlinx.dnq.query.first
+import kotlinx.dnq.query.toList
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Covers the restored `transactional(readonly = true)` semantics:
+ * requested-readonly sessions, write rejection, mismatch-suspend nesting,
+ * and requested-readonly persistent-transaction lifecycle across flush/revert.
+ */
+class ReadonlyTransactionalTest : DBTest() {
+
+    @Test
+    fun `readonly session reports isReadonly and opens a readonly persistent transaction`() {
+        transactional(readonly = true) { txn ->
+            assertThat(txn.isReadonly).isTrue()
+            assertThat(txn.transactionInternal.isReadonly).isTrue()
+        }
+        transactional { txn ->
+            assertThat(txn.isReadonly).isFalse()
+            assertThat(txn.transactionInternal.isReadonly).isFalse()
+        }
+    }
+
+    @Test
+    fun `write inside readonly throws and session stays usable after catch`() {
+        transactional {
+            User.new { login = "existing"; skill = 1 }
+        }
+
+        transactional(readonly = true) { txn ->
+            assertFailsWith<ReadonlyTransactionException> {
+                User.new { login = "rejected"; skill = 1 }
+            }
+
+            // the session must still be open, readonly and usable
+            assertThat(txn.isOpened).isTrue()
+            assertThat(txn.isReadonly).isTrue()
+            assertThat(txn.hasChanges()).isFalse()
+            assertQuery(User.all()).hasSize(1)
+
+            // property writes are also rejected, again without corrupting the session
+            val user = User.all().first()
+            assertFailsWith<ReadonlyTransactionException> {
+                user.name = "new name"
+            }
+            assertThat(user.login).isEqualTo("existing")
+        }
+
+        transactional {
+            assertThat(User.all().toList().map { it.login }).containsExactly("existing")
+        }
+    }
+
+    @Test
+    fun `no-op link mutation inside readonly also throws`() {
+        transactional {
+            User.new { login = "existing"; skill = 1 }
+        }
+
+        transactional(readonly = true) {
+            val user = User.all().first()
+            assertThat(user.supervisor).isNull()
+            // setting an absent link to null is a logical no-op, but the write attempt
+            // is rejected eagerly (accepted AD-2 strictness)
+            assertFailsWith<ReadonlyTransactionException> {
+                user.supervisor = null
+            }
+        }
+    }
+
+    @Test
+    fun `readonly outer with plain inner suspends into an independent committing transaction`() {
+        var innerSession: TransientStoreSession? = null
+
+        transactional(readonly = true) { outer ->
+            transactional { inner ->
+                innerSession = inner
+                assertThat(inner).isNotSameInstanceAs(outer)
+                assertThat(inner.isReadonly).isFalse()
+                User.new { login = "inner-user"; skill = 1 }
+                // inner commits independently on block exit
+            }
+
+            // the outer readonly session is restored and still rejects writes
+            assertThat(store.threadSession).isSameInstanceAs(outer)
+            assertThat(outer.isReadonly).isTrue()
+            assertFailsWith<ReadonlyTransactionException> {
+                User.new { login = "outer-user"; skill = 1 }
+            }
+        }
+
+        assertThat(innerSession).isNotNull()
+        transactional {
+            assertThat(User.all().toList().map { it.login }).containsExactly("inner-user")
+        }
+    }
+
+    @Test
+    fun `plain outer with readonly inner suspends into an independent readonly transaction`() {
+        transactional { outer ->
+            User.new { login = "outer-user"; skill = 1 }
+
+            transactional(readonly = true) { inner ->
+                assertThat(inner).isNotSameInstanceAs(outer)
+                assertThat(inner.isReadonly).isTrue()
+                assertFailsWith<ReadonlyTransactionException> {
+                    User.new { login = "inner-user"; skill = 1 }
+                }
+            }
+
+            // the outer session is restored and still writable
+            assertThat(store.threadSession).isSameInstanceAs(outer)
+            User.new { login = "outer-user-2"; skill = 2 }
+        }
+
+        transactional {
+            assertThat(User.all().toList().map { it.login })
+                .containsExactly("outer-user", "outer-user-2")
+        }
+    }
+
+    @Test
+    fun `flush does not make a nested plain transactional suspend`() {
+        transactional { txn ->
+            User.new { login = "before-flush"; skill = 1 }
+            txn.flush()
+            // flush flips the mutable readonly flag; the session was requested writable though
+            assertThat(txn.isReadonly).isTrue()
+
+            transactional { inner ->
+                // no mismatch: the session is reused, not suspended
+                assertThat(inner).isSameInstanceAs(txn)
+                User.new { login = "after-flush"; skill = 1 }
+            }
+        }
+
+        transactional {
+            assertThat(User.all().toList().map { it.login })
+                .containsExactly("before-flush", "after-flush")
+        }
+    }
+
+    @Test
+    fun `findOrNew found in readonly session - flush reopens a readonly persistent transaction`() {
+        transactional {
+            User.new { login = "existing"; skill = 1 }
+        }
+
+        transactional(readonly = true) { txn ->
+            val found = User.findOrNew { login = "existing"; skill = 1 }
+            assertThat(found.login).isEqualTo("existing")
+            // the found-branch queues a change without hitting the readonly check
+            assertThat(txn.hasChanges()).isTrue()
+
+            txn.flush()
+
+            assertThat(txn.hasChanges()).isFalse()
+            assertThat(txn.transactionInternal.isReadonly).isTrue()
+        }
+    }
+
+    @Test
+    fun `findOrNew found in readonly session - revert clears changes and stays readonly`() {
+        transactional {
+            User.new { login = "existing"; skill = 1 }
+        }
+
+        transactional(readonly = true) { txn ->
+            User.findOrNew { login = "existing"; skill = 1 }
+            assertThat(txn.hasChanges()).isTrue()
+
+            txn.revert()
+
+            assertThat(txn.hasChanges()).isFalse()
+            assertThat(txn.transactionInternal.isReadonly).isTrue()
+        }
+    }
+
+    @Test
+    fun `findOrNew found in readonly session - implicit end-of-block commit completes`() {
+        transactional {
+            User.new { login = "existing"; skill = 1 }
+        }
+
+        transactional(readonly = true) { txn ->
+            val found = User.findOrNew { login = "existing"; skill = 1 }
+            assertThat(found.login).isEqualTo("existing")
+            assertThat(txn.hasChanges()).isTrue()
+            // no explicit flush()/revert(): the block ends normally and commit()
+            // drives the flush loop over the pending queued change
+        }
+
+        transactional {
+            // no duplicate was created and nothing leaked from the readonly session
+            assertThat(User.all().toList().map { it.login }).containsExactly("existing")
+        }
+    }
+
+    @Test
+    fun `entity captured in readonly outer is mutated via the suspended-into plain inner and persists`() {
+        transactional {
+            User.new { login = "captured"; skill = 1 }
+        }
+
+        transactional(readonly = true) {
+            // capture an entity in the readonly outer session
+            val captured = User.all().first()
+
+            // the plain inner block suspends into an independent RW transaction;
+            // the captured entity is mutated from inside that inner context
+            transactional {
+                captured.skill = 42
+            }
+        }
+
+        // the inner transaction committed independently: the write must be durable
+        transactional {
+            val user = User.all().first()
+            assertThat(user.skill).isEqualTo(42)
+        }
+    }
+
+    @Test
+    fun `beginReadonlyTransaction returns the existing requested-readonly session`() {
+        transactional(readonly = true) { txn ->
+            assertThat(store.beginReadonlyTransaction()).isSameInstanceAs(txn)
+        }
+    }
+
+    @Test
+    fun `beginReadonlyTransaction fails fast on an existing writable session`() {
+        transactional { txn ->
+            assertFailsWith<IllegalStateException> {
+                store.beginReadonlyTransaction()
+            }
+            // the writable session is untouched
+            assertThat(store.threadSession).isSameInstanceAs(txn)
+        }
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionsTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/concurrent/transaction/ReadonlyTransactionsTest.kt
@@ -74,11 +74,17 @@ class ReadonlyTransactionsTest : DBTest() {
     }
 
     @Test
-    fun `WD-2051 Nested transactional block is still read only`() {
-        transactional(readonly = true) {
-            transactional {
+    fun `WD-2051 Nested plain transactional block suspends into an independent committing transaction`() {
+        transactional(readonly = true) { outer ->
+            transactional { inner ->
+                assertThat(inner).isNotSameInstanceAs(outer)
                 Something.all().first().i1 = 1729
             }
+            // the outer session remains readonly after the inner block commits
+            assertThat(outer.isReadonly).isTrue()
+        }
+        transactional {
+            assertThat(Something.all().toList().count { it.i1 == 1729 }).isEqualTo(1)
         }
     }
 


### PR DESCRIPTION
## Motivation

The `readonly` flag of `TransientEntityStore.transactional` is currently dropped on
the floor in the YTDB fork: it was deliberately (temporarily) removed in a5985c58,
and only the `isNew` half was restored in 9792279c — the readonly half never was.

Downstream consumers classify exceptions by the exact type
`jetbrains.exodus.env.ReadonlyTransactionException` being thrown for write attempts
inside read-only transactions (matched by `is`-check, no unwrapping). With the flag
dropped, readonly semantics silently regressed: every "readonly" block actually runs
in a plain writable session and that exception never surfaces.

## Changes

Single-track change: 3 main files in `dnq-transient-store`
(`TransientEntityStoreExt.kt`, `TransientEntityStoreImpl.kt`,
`TransientSessionImpl.kt`) plus tests in the `dnq` module.

1. `TransientEntityStoreExt.transactional` gains `readonly: Boolean = false`: with no
   current session it starts a new session via `startNewAndRun(readonly)`; on `isNew`
   or a requested-readonly mismatch it suspends into an independent transaction via
   `suspendAndRun(readonly)` using the fork's YTDB-safe suspend infrastructure; on a
   match it reuses the current session. The mismatch check reads requested-readonly
   via safe-cast `(session as? TransientSessionImpl)?.requestedReadonly ?:
   session.isReadonly` (no public API change). `beginSession(readonly)` calls
   `beginReadonlyTransaction()` when readonly, else `beginSession()`.
2. `TransientEntityStoreImpl.transactional` forwards `readonly`;
   `beginReadonlyTransaction()` mirrors `beginSession()`'s existing-session guard with
   an explicit rule (AD-8): an existing current session that is itself
   requested-readonly is returned; an existing session that is NOT requested-readonly
   throws (fail fast) — a writable session is never handed to a readonly request.
3. `TransientSessionImpl` gains an immutable `requestedReadonly` val, distinct from
   the mutable `isReadonly` that flips on `flush()`/`revert()` (a fork-internal
   "quiescent" state — reusing it for dispatch would falsely mismatch after a
   mid-block flush and spawn an independent committing transaction).
   `upgradeReadonlyTransactionIfNecessary()` throws
   `jetbrains.exodus.env.ReadonlyTransactionException` when the session was
   requested-readonly, BEFORE any state mutation (no `readonly=false` flip / tracker
   swap on the throw path, AD-1), so catch-and-continue leaves the session consistent.
4. Requested-readonly sessions open their persistent transaction via
   `persistentStore.beginReadonlyTransaction()` (defense-in-depth: YTDB's
   `requireActiveWritableTransaction` backstops raw entity-layer writes that bypass
   DNQ change tracking); `revert()` and `flush()` reopen the persistent transaction
   readonly for such sessions (AD-6: the has-changes flush branch is reachable in
   requested-readonly sessions via `findOrNew` → `addEntityCreator` found-branch,
   which queues a change without hitting the readonly check).
5. `revert()`'s `if (!transactionInternal.isReadonly)` gate is fixed (AD-7): revert
   now always clears `loadedIds`/`entitiesUpdater` regardless of persistent-tx
   readonly-ness, otherwise `hasChanges()` stays true after revert in
   requested-readonly sessions. Additionally (review hardening, CQ-1), the
   `NeedRetryException` replay path in `flushChanges()` throws
   `ReadonlyTransactionException` for requested-readonly sessions and routes
   transaction acquisition through the shared `beginPersistentTransaction()` helper.
6. Tests: readonly session reports `isReadonly`; write inside readonly throws (session
   still usable after catch); no-op mutation throws; mismatch-suspend nesting in both
   directions; flush-then-nest reuses the session; findOrNew-found in a readonly
   session: flush reopens readonly (AD-6), revert clears changes (AD-7), and implicit
   end-of-block commit completes; cross-suspend captured-entity mutation persists
   (CN-1 regression); direct `beginReadonlyTransaction` guard behavior (AD-8).

## Behavior changes (approved)

1. **Nesting suspend:** readonly-outer + plain-inner nesting now suspends into an
   independent committing RW transaction (previously the session was reused and the
   inner block silently wrote through the "readonly" outer transaction).
2. **Write-throws:** writes inside requested-readonly sessions now throw
   `jetbrains.exodus.env.ReadonlyTransactionException` instead of silently upgrading
   the transaction to read-write.
3. **No-op-write-throws:** logical no-op mutations (e.g. `setToOne(e, link, null)`
   with no existing link) also throw — stricter than upstream's lazy throw, since the
   check runs eagerly before the change is evaluated.

## Risks & accepted trade-offs

Three approved behavior changes (nesting suspend, write-throws, no-op-write-throws —
the latter stricter than upstream's lazy throw, revisit if downstream test runs
surface no-op-write failures); readonly enforcement is DNQ-level first with a YTDB
client-side backstop, still no DB-level enforcement.

## Testing

- New `ReadonlyTransactionalTest` (12 tests, `dnq` module): isReadonly reporting +
  readonly persistent tx; write-throws with session-usable-after-catch; no-op-write
  throws; mismatch-suspend nesting both directions; flush-then-nest session reuse;
  findOrNew-found flush/revert/implicit-commit in readonly sessions; cross-suspend
  captured-entity mutation persistence (CN-1 regression); `beginReadonlyTransaction`
  guard behavior.
- `ReadonlyTransactionsTest` WD-2051 rewritten: readonly-outer + plain-inner now
  asserts suspend semantics (independent session, outer stays readonly, inner write
  committed independently).
- Affected suites green: `ReadonlyTransactionalTest`, `ReadonlyTransactionsTest`,
  `HasChangesTest`, `NewTransactionTest`, `SnapshotIsolationTest` — 66/66 passed
  (2 pre-existing unrelated skips: `@Ignore` YTDB-510 snapshot-isolation tests).

## Review record

Design review: user-approved — 2026-07-29 (refreshed after adversarial round 1
reversals AD-1, AD-3)

Adversarial review round 1: 5 findings (AD-1..AD-5) triaged with user — 2 reversed,
1 accepted-as-risk, 2 incorporated — 2026-07-29.

Adversarial review round 2 (targeted, post-reversal): 3 findings (AD-6..AD-8), all
incorporated, no reversals — 2026-07-29.

Adversarial review: passed, 1 accepted risk (AD-2 no-op-write strictness) — 2026-07-29

Code review: agent code review completed 2026-07-29 (baseline + concurrency
perspectives): 0 bugs, CN-1 should-fix resolved not-a-defect with regression test,
CQ-1/TQ-2 addressed; CQ-2, CQ-3, TQ-1, CN-2, CN-3 deferred as follow-up hardening
items.
