### PR TITLE
XD-1292 Restore the Xodus EntityIterable and EntityIterator contracts on YouTrackDB

### DIFF
--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
@@ -437,10 +437,16 @@ class YTDBStoreTransactionImpl(
         polymorphic: Boolean
     ): YTDBEntityIterable {
         requireActiveTransaction()
-        return if (entities === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
+        // Normalise the operand before the identity guard, for the same reasons as
+        // YTDBEntityIterableImpl.operand(): wrappers expose their query form only through unwrap(),
+        // and a wrapper around EMPTY is not identical to EMPTY. This method has no access to that
+        // private helper, so it unwraps locally. This is the one findLinks overload reachable from the
+        // public session API (SessionQueryMixin forwards `entities` unchanged).
+        val operand = entities.unwrap()
+        return if (operand === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
         else YTDBEntityIterable.query(
             getStore(),
-            entities.asYTDBIterable().query
+            operand.asYTDBIterable().query
                 .then(GremlinBlock.InLink(linkName))
                 .then(GremlinBlock.HasLabel(entityType)),
             polymorphic

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/gremlin/GremlinQuery.kt
@@ -17,7 +17,6 @@ package jetbrains.exodus.entitystore.youtrackdb.gremlin
 
 import com.jetbrains.youtrackdb.api.gremlin.embedded.YTDBVertex
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID
-import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock.SortDirection
 import org.apache.tinkerpop.gremlin.process.traversal.P
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
@@ -46,11 +45,6 @@ sealed class GremlinQuery {
         block is GremlinBlock.OutLink -> FollowLink(this, LinkDirection.OUT, block.linkName)
 
         block is GremlinBlock.AndThen -> throw IllegalArgumentException("Nested andThen is not allowed")
-        block is GremlinBlock.Reverse -> when (this) {
-            is SortBy -> this.reverseOrder()
-            is ReversedOrder -> this.inner
-            else -> ReversedOrder(this)
-        }
 
         else -> when (this) {
             is Where -> Where(this.block.andThen(block))
@@ -439,13 +433,6 @@ sealed class GremlinQuery {
         companion object {
             fun of(query: GremlinQuery, sortBlock: GremlinBlock.Sort): GremlinQuery = SortBy(query, sortBlock)
         }
-
-        fun reverseOrder(): SortBy = this.copy(
-            inner = inner, sortBlock = sortBlock.copy(
-                by = sortBlock.by,
-                direction = if (sortBlock.direction == SortDirection.ASC) SortDirection.DESC else SortDirection.ASC
-            )
-        )
     }
 
     data class ReversedOrder(val inner: GremlinQuery) : Chained(inner, GremlinBlock.Reverse)

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
@@ -217,39 +217,50 @@ class YTDBEntityIterableImpl(
             .use { it.hasNext() }
     }
 
-    override fun intersect(right: EntityIterable): EntityIterable =
-        if (right === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
-        else {
-            val rightIterable = right.asYTDBIterable()
-            requirePolymorphicMatch(rightIterable)
-            YTDBEntityIterableImpl(oStore,query.intersect(rightIterable.query), polymorphic)
-        }
+    override fun intersect(right: EntityIterable): EntityIterable {
+        val rightIterable = right.operand()
+        if (rightIterable === YTDBEntityIterable.EMPTY) return YTDBEntityIterable.EMPTY
+        requirePolymorphicMatch(rightIterable)
+        return YTDBEntityIterableImpl(oStore, query.intersect(rightIterable.query), polymorphic)
+    }
 
     override fun intersectSavingOrder(right: EntityIterable): EntityIterable = intersect(right)
 
-    override fun union(right: EntityIterable): EntityIterable =
-        if (right === YTDBEntityIterable.EMPTY) this
-        else {
-            val rightIterable = right.asYTDBIterable()
-            requirePolymorphicMatch(rightIterable)
-            YTDBEntityIterableImpl(oStore,query.union(rightIterable.query), polymorphic)
-        }
+    override fun union(right: EntityIterable): EntityIterable {
+        val rightIterable = right.operand()
+        if (rightIterable === YTDBEntityIterable.EMPTY) return this
+        requirePolymorphicMatch(rightIterable)
+        return YTDBEntityIterableImpl(oStore, query.union(rightIterable.query), polymorphic)
+    }
 
-    override fun minus(right: EntityIterable): EntityIterable =
-        if (right === YTDBEntityIterable.EMPTY) this
-        else {
-            val rightIterable = right.asYTDBIterable()
-            requirePolymorphicMatch(rightIterable)
-            YTDBEntityIterableImpl(oStore,query.difference(rightIterable.query), polymorphic)
-        }
+    override fun minus(right: EntityIterable): EntityIterable {
+        val rightIterable = right.operand()
+        if (rightIterable === YTDBEntityIterable.EMPTY) return this
+        requirePolymorphicMatch(rightIterable)
+        return YTDBEntityIterableImpl(oStore, query.difference(rightIterable.query), polymorphic)
+    }
 
-    override fun concat(right: EntityIterable): EntityIterable =
-        if (right === YTDBEntityIterable.EMPTY) this
-        else {
-            val rightIterable = right.asYTDBIterable()
-            requirePolymorphicMatch(rightIterable)
-            YTDBEntityIterableImpl(oStore,query.unionAll(rightIterable.query), polymorphic)
-        }
+    override fun concat(right: EntityIterable): EntityIterable {
+        val rightIterable = right.operand()
+        if (rightIterable === YTDBEntityIterable.EMPTY) return this
+        requirePolymorphicMatch(rightIterable)
+        return YTDBEntityIterableImpl(oStore, query.unionAll(rightIterable.query), polymorphic)
+    }
+
+    /**
+     * Normalises an operand to its query form. Wrappers — `PersistentEntityIterableWrapper`,
+     * `SnapshotEntityIterable`, `YTDBVertexEntityIterable` — expose that form only through [unwrap];
+     * casting before unwrapping fails in `asYTDBIterable` for the ones that are not themselves a
+     * [YTDBEntityIterable].
+     *
+     * **Call this BEFORE the `=== EMPTY` identity guard, never after.** A wrapper around EMPTY is not
+     * identical to EMPTY, so a guard on the raw argument misses it and then reads `EMPTY.query`, which
+     * is `unsupported`. Unwrapping first is safe for EMPTY itself: `EMPTY.unwrap()` returns EMPTY and
+     * EMPTY is a [YTDBEntityIterable], so the cast passes and the guard still fires.
+     *
+     * One helper for all five operand sites, so they cannot drift apart again.
+     */
+    private fun EntityIterable.operand(): YTDBEntityIterable = unwrap().asYTDBIterable()
 
     private fun requirePolymorphicMatch(right: YTDBEntityIterable) {
         require(polymorphic == right.polymorphic) {
@@ -317,16 +328,18 @@ class YTDBEntityIterableImpl(
     // receiver entity, and the intersection may compile to a form driven by the in-link traversal
     // (`in()` is many-out-per-in), which would then emit that entity once per edge.
     //
-    // The `entities === EMPTY` short-circuit must be kept: EMPTY.query is `unsupported`.
+    // The EMPTY short-circuit must be kept (EMPTY.query is `unsupported`) and must test the UNWRAPPED
+    // argument: a wrapper around EMPTY is not identical to EMPTY, and unwrap() is identity for both
+    // EMPTY and YTDBEntityIterableImpl. See operand() for why the order matters.
     override fun findLinks(
         entities: EntityIterable,
         linkName: String
-    ): EntityIterable =
-        if (entities === YTDBEntityIterable.EMPTY) YTDBEntityIterable.EMPTY
-        else {
-            val byLink = entities.asYTDBIterable().query.then(GremlinBlock.InLink(linkName))
-            YTDBEntityIterableImpl(oStore, query.intersect(byLink), polymorphic).distinct()
-        }
+    ): EntityIterable {
+        val operand = entities.operand()
+        if (operand === YTDBEntityIterable.EMPTY) return YTDBEntityIterable.EMPTY
+        val byLink = operand.query.then(GremlinBlock.InLink(linkName))
+        return YTDBEntityIterableImpl(oStore, query.intersect(byLink), polymorphic).distinct()
+    }
 
     override fun idSet(): EntityIdSet =
         this.fold(EntityIdSetFactory.newSet()) { acc, e -> acc.add(e.id) }

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterable.kt
@@ -270,12 +270,23 @@ class YTDBEntityIterableImpl(
         }
     }
 
+    /**
+     * Non-positive [number] is clamped, per Xodus's `EntityIterableBase.skip`
+     * (`if (number <= 0 || store == null) return this`): a negative argument is a no-op, not an error.
+     * The `require(skip >= 0)` guard in [GremlinBlock.Skip] stays — it is an internal invariant now
+     * that this entry point clamps.
+     */
     override fun skip(number: Int): EntityIterable =
-        if (number == 0) this
+        if (number <= 0) this
         else modify(GremlinBlock.Skip(number.toLong()))
 
+    /**
+     * Non-positive [number] yields the empty iterable, per Xodus's `EntityIterableBase.take`
+     * (`if (number <= 0 || store == null) return EMPTY`). As with [skip], the `require(limit >= 0)`
+     * guard in [GremlinBlock.Limit] remains an internal invariant.
+     */
     override fun take(number: Int): EntityIterable =
-        if (number == 0) YTDBEntityIterable.EMPTY
+        if (number <= 0) YTDBEntityIterable.EMPTY
         else modify(GremlinBlock.Limit(number.toLong()))
 
     override fun distinct(): EntityIterable = modify(GremlinBlock.Dedup)

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterator.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterator.kt
@@ -46,6 +46,12 @@ class YTDBEntityIterator(
 
     }
 
+    /**
+     * Skips up to [number] entities and returns the value of [hasNext], per the
+     * [EntityIterator.skip] contract. Note [hasNext] disposes the traversal on exhaustion, so
+     * `skip(n)` that runs off the end closes it — a divergence from Xodus's `EntityIteratorBase.skip`,
+     * which drives the walk with the non-disposing `hasNextImpl()`.
+     */
     override fun skip(number: Int): Boolean {
         repeat(number) {
             if (!hasNext()) {
@@ -53,7 +59,7 @@ class YTDBEntityIterator(
             }
             next()
         }
-        return true
+        return hasNext()
     }
 
     override fun nextId(): EntityId = next().id

--- a/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBVertexEntityIterable.kt
+++ b/dnq-entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBVertexEntityIterable.kt
@@ -30,8 +30,6 @@ import jetbrains.exodus.entitystore.youtrackdb.resolveTypeName
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
 import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinQuery
 import org.apache.commons.collections4.IterableUtils
-import org.apache.commons.collections4.IteratorUtils
-import org.apache.commons.collections4.functors.EqualPredicate
 
 class YTDBVertexEntityIterable(
     private val tx: YTDBStoreTransaction,
@@ -45,12 +43,31 @@ class YTDBVertexEntityIterable(
 
         private val iterator = vertices.iterator()
 
-        override fun skip(number: Int) =
-            (0 until number).count { iterator.hasNext() }.also { iterator.next() } == number
+        /**
+         * Skips up to [number] entities and returns the value of `hasNext()`, per the
+         * [EntityIterator.skip] contract (Xodus: `while (number-- > 0 && hasNextImpl()) nextIdImpl();
+         * return hasNextImpl()`).
+         *
+         * A non-positive [number] consumes nothing. Note this must *consume* — the previous form
+         * counted `hasNext()` (which consumes nothing) and then consumed exactly one element
+         * unconditionally, which is what made [getLast] return the wrong element or throw.
+         */
+        override fun skip(number: Int): Boolean {
+            var left = number
+            while (left-- > 0 && iterator.hasNext()) {
+                iterator.next()
+            }
+            return iterator.hasNext()
+        }
 
         override fun nextId() = RIDEntityId.fromVertex(iterator.next())
 
-        override fun dispose() = true
+        /**
+         * Nothing is held — [vertices] is an already-materialised `List` — so nothing can be
+         * released, and `dispose()`'s contract is "`true` if the `EntityIterator` was actually
+         * disposed". Keep this consistent with [shouldBeDisposed].
+         */
+        override fun dispose() = false
 
         override fun shouldBeDisposed() = false
 
@@ -81,9 +98,30 @@ class YTDBVertexEntityIterable(
 
     override fun getRoughSize() = count()
 
-    override fun indexOf(entity: Entity) = IteratorUtils.indexOf(iterator(), EqualPredicate.equalPredicate(entity))
+    /**
+     * Compares [jetbrains.exodus.entitystore.EntityId]s, matching the sibling
+     * [YTDBEntityIterableImpl.indexOf] and Xodus's `EntityIterableBase.indexOfImpl`.
+     *
+     * The previous commons-collections form (`IteratorUtils.indexOf(iterator(),
+     * EqualPredicate.equalPredicate(entity))`) compared *objects*, and argument-first at that, so a
+     * foreign `Entity` implementation carrying a member's id missed: `YTDBVertexEntity.equals` has a
+     * `javaClass` check and `TransientEntityImpl.equals` rejects any non-`TransientEntity` before it
+     * ever looks at the id. Id comparison is safe across implementations — `RIDEntityId.equals`
+     * compares `(typeId, localId)` against any [jetbrains.exodus.entitystore.EntityId].
+     */
+    override fun indexOf(entity: Entity): Int {
+        val id = entity.id
+        val it = iterator()
+        var i = 0
+        while (it.hasNext()) {
+            if (it.nextId() == id) return i
+            ++i
+        }
+        return -1
+    }
 
-    override fun contains(entity: Entity) = IteratorUtils.contains(iterator(), entity)
+    /** Per the `EntityIterable.contains` contract: "just returns `indexOf(entity) != -1`". */
+    override fun contains(entity: Entity) = indexOf(entity) != -1
 
     override fun intersect(right: EntityIterable) = asQueryIterable().intersect(right)
 
@@ -108,7 +146,18 @@ class YTDBVertexEntityIterable(
 
     override fun getFirst() = iterator().run { if (hasNext()) next() else null }
 
-    override fun getLast() = iterator().run { if (hasNext()) skip(count().toInt() - 1).run { next() } else null }
+    /**
+     * Walks to the last element. Deliberately independent of [count] (which returns `-1` for a
+     * non-`Collection`, non-`Sizeable` source) and of [skip].
+     */
+    override fun getLast(): Entity? {
+        var last: Entity? = null
+        val it = iterator()
+        while (it.hasNext()) {
+            last = it.next()
+        }
+        return last
+    }
 
     override fun reverse() = asQueryIterable().reverse()
 

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntityTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntityTest.kt
@@ -16,9 +16,14 @@
 package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType
+import io.mockk.every
+import io.mockk.mockk
+import jetbrains.exodus.entitystore.Entity
 import jetbrains.exodus.entitystore.EntityRemovedInDatabaseException
 import jetbrains.exodus.entitystore.PersistentEntityId
+import com.jetbrains.youtrackdb.api.gremlin.embedded.YTDBVertex
 import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity.Companion.linkTargetEntityIdPropertyName
+import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBVertexEntityIterable
 import jetbrains.exodus.entitystore.youtrackdb.testutil.*
 import jetbrains.exodus.entitystore.youtrackdb.testutil.Issues.Links.IN_PROJECT
 import org.junit.Assert
@@ -169,6 +174,230 @@ class YTDBEntityTest : OTestMixin {
 
         youTrackDb.withStoreTx {
             assertNamesExactlyInOrder(source.getLinks(linkName), *names.toTypedArray())
+        }
+    }
+
+    /**
+     * XD-1292 / audit #3 — the anonymous [jetbrains.exodus.entitystore.EntityIterator] returned by
+     * `YTDBVertexEntityIterable.iterator()`.
+     *
+     * Contract ([jetbrains.exodus.entitystore.EntityIterator.skip]): *"Skips specified number of
+     * entities and returns the value of `hasNext()`"* — i.e. `skip(n)` must **consume** up to `n`
+     * elements and then answer "is anything left", not "did I manage to count n".
+     *
+     * **Every assertion builds a FRESH `iterator()`. This is load-bearing, not hygiene:** each row is
+     * a statement about the *initial* iterator state, so a shared iterator would make later rows
+     * depend on how much earlier rows consumed. `iterator()` is cheap — `getLinks` materialises a
+     * sorted `List` and the iterator just walks it.
+     *
+     * Expected elements are derived from `links.toList()` rather than from the order the links were
+     * added: since `getLinks` sorts targets ascending by entity id, insertion order is not the
+     * iteration order.
+     */
+    @Test
+    fun `getLinks iterator skip advances by n and returns hasNext`() {
+        val linkName = "link"
+        youTrackDb.withSession { session ->
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+        }
+
+        val (source, unlinked) = youTrackDb.withStoreTx { tx ->
+            val source = tx.createIssue("source")
+            val unlinked = tx.createIssue("unlinked")
+            val names = listOf("A", "B", "C", "D")
+            val created = names.associateWith { tx.createIssue(it) }
+            // scrambled attach order, so insertion order != id order
+            listOf("D", "B", "A", "C").forEach { source.addLink(linkName, created.getValue(it)) }
+            source to unlinked
+        }
+
+        youTrackDb.withStoreTx {
+            val links = source.getLinks(linkName)
+            val expected = links.toList().map { it.id }
+            assertEquals(4, expected.size)
+
+            // skip(0) must consume nothing
+            assertEquals(expected[0], links.iterator().let { it.skip(0); it.next().id })
+
+            // skip(2) must consume exactly two
+            assertEquals(expected[2], links.iterator().let { it.skip(2); it.next().id })
+
+            // skip(size) lands past the end -> hasNext() == false
+            assertFalse(links.iterator().skip(4))
+
+            // skip(size - 1) leaves exactly one element
+            assertTrue(links.iterator().skip(3))
+            assertEquals(expected[3], links.iterator().let { it.skip(3); it.next().id })
+
+            // negative n: a no-op that consumes nothing and reports hasNext()
+            assertTrue(links.iterator().skip(-1))
+            assertEquals(expected[0], links.iterator().let { it.skip(-1); it.next().id })
+
+            // empty link set: skip must return false, not throw
+            val noLinks = unlinked.getLinks(linkName)
+            assertFalse(noLinks.iterator().skip(0))
+            assertFalse(noLinks.iterator().skip(1))
+            assertFalse(noLinks.iterator().skip(-1))
+        }
+    }
+
+    /**
+     * XD-1292 / audit #4 — `YTDBVertexEntityIterable.getLast()`.
+     *
+     * Sizes 0/1/2/3 in one test. Today size 1 throws `NoSuchElementException`, size 2 passes by
+     * accident and size 3 returns the element at index 1; size 0 must stay `null` (a
+     * preserved-behaviour pin, not a regression assertion).
+     *
+     * Expectations are derived from `getLinks(link).toList()`, not from the attach order: `getLinks`
+     * sorts its targets ascending by entity id.
+     */
+    @Test
+    fun `getLinks getLast returns the last link`() {
+        val linkName = "link"
+        youTrackDb.withSession { session ->
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+        }
+
+        val sources = youTrackDb.withStoreTx { tx ->
+            (0..3).map { size ->
+                val source = tx.createIssue("source$size")
+                val targets = (0 until size).map { tx.createIssue("t$size-$it") }
+                // reversed attach order, so insertion order != id order for size >= 2
+                targets.reversed().forEach { source.addLink(linkName, it) }
+                source
+            }
+        }
+
+        youTrackDb.withStoreTx {
+            sources.forEachIndexed { size, source ->
+                val links = source.getLinks(linkName)
+                val expected = links.toList().lastOrNull()?.id
+                assertEquals(size, links.toList().size)
+                assertEquals(expected, links.last?.id, "getLast() on a link set of size $size")
+            }
+        }
+    }
+
+    /**
+     * XD-1292 / audit #4, the row that pins the `getLast()` **rewrite** rather than the `skip()` fix.
+     *
+     * The three rows above go through `YTDBVertexEntity.getLinks`, which always hands
+     * [YTDBVertexEntityIterable] an already-materialised `List`. With a `List` source `count()` is
+     * exact, so once `skip()` consumes correctly the old `skip(count() - 1) + next()` form happens to
+     * be right too — those rows cannot tell the two implementations apart.
+     *
+     * The rewrite's actual claim is **independence from `count()`**, which returns `-1` for any source
+     * that is neither a `Collection` nor a `Sizeable` (`YTDBVertexEntityIterable.count()`). The
+     * constructor is public, so that source is constructible: with `count() == -1` the old form
+     * evaluates `skip(-2)`, which consumes nothing and returns `hasNext()`, and then `next()` yields
+     * element **0** instead of the last. This test is therefore the one that fails if the `getLast`
+     * edit alone is reverted.
+     */
+    @Test
+    fun `getLast does not depend on count for a non-Collection source`() {
+        val linkName = "link"
+        youTrackDb.withSession { session ->
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+        }
+        val (source, targets) = youTrackDb.withStoreTx { tx ->
+            val source = tx.createIssue("lazySource")
+            source to (0..2).map { tx.createIssue("lazyTarget$it") }
+        }
+
+        withStoreTx { tx ->
+            val vertices = targets.map { it.vertex }
+            // Neither a Collection nor a Sizeable, so count() cannot answer.
+            val lazySource: Iterable<YTDBVertex> = Iterable { vertices.iterator() }
+            val iterable = YTDBVertexEntityIterable(tx, lazySource, tx.getStore(), linkName, source.id)
+
+            // Precondition: this is exactly the shape the count()-based form cannot handle.
+            assertEquals(-1L, iterable.count())
+            assertEquals(3, iterable.toList().size)
+
+            assertEquals(targets.first().id, iterable.first?.id)
+            assertEquals(targets.last().id, iterable.last?.id)
+        }
+    }
+
+    /**
+     * XD-1292 / audit #11 — `YTDBVertexEntityIterable.contains`/`indexOf` must compare `EntityId`s,
+     * not objects.
+     *
+     * The old form went through commons-collections `IteratorUtils` + `EqualPredicate`, which is
+     * **argument-first**: it runs the *argument's* `equals`. So a foreign `Entity` implementation
+     * carrying a member's id missed — either because `YTDBVertexEntity.equals` has a
+     * `javaClass != other.javaClass` check, or (the realistic DNQ case) because
+     * `TransientEntityImpl.equals` rejects any non-`TransientEntity` before comparing ids.
+     *
+     * Three guards, all mandatory:
+     *  1. the positive target sits at a **non-zero** index and the index is asserted exactly —
+     *     otherwise `indexOf(e) = if (contains(e)) 0 else -1` would pass;
+     *  2. a **cross-type collision** control: `localId` sequences are per class, so a Board with the
+     *     same `localId` as the target Issue really exists — an implementation comparing only
+     *     `localId` must fail here;
+     *  3. an **absent** same-type entity control.
+     */
+    @Test
+    fun `getLinks contains and indexOf compare entity ids`() {
+        val test = givenTestCase()
+        withStoreTx { tx ->
+            // board1 -> HasIssue -> all three issues, so the link set has size 3
+            tx.addIssueToBoard(test.issue1, test.board1)
+            tx.addIssueToBoard(test.issue2, test.board1)
+            tx.addIssueToBoard(test.issue3, test.board1)
+        }
+
+        // guard 3's subject: a same-type entity that is simply not in the link set
+        val absentIssue = youTrackDb.createIssue("absent")
+
+        withStoreTx {
+            val links = test.board1.getLinks(Boards.Links.HAS_ISSUE)
+            val members = links.toList()
+            assertEquals(3, members.size)
+
+            // GUARD 1 - positive row on a NON-FIRST element, exact index asserted.
+            val targetIndex = members.size - 1
+            val target = members[targetIndex]
+            assertTrue(targetIndex > 0, "the positive row must not target index 0")
+            val foreignWrapper = mockk<Entity> { every { id } returns target.id }
+            assertEquals(targetIndex, links.indexOf(foreignWrapper))
+            assertTrue(links.contains(foreignWrapper))
+
+            // GUARD 2 - cross-type collision: same localId, different typeId, must NOT be found.
+            val collider = listOf(test.board1, test.board2, test.board3)
+                .first { it.id.localId == target.id.localId }
+            assertNotEquals(collider.id.typeId, target.id.typeId, "collider must be of another type")
+            assertEquals(collider.id.localId, target.id.localId, "collider must share the localId")
+            assertFalse(links.contains(collider))
+            assertEquals(-1, links.indexOf(collider))
+
+            // GUARD 3 - an absent entity of the same type.
+            assertFalse(links.contains(absentIssue))
+            assertEquals(-1, links.indexOf(absentIssue))
+        }
+    }
+
+    /**
+     * XD-1292 / audit #21 — the anonymous iterator's `dispose()` claimed `true` ("the EntityIterator
+     * was actually disposed") while holding nothing and while `shouldBeDisposed()` said `false`.
+     * Both halves are asserted so the pair cannot drift apart again.
+     */
+    @Test
+    fun `getLinks iterator is honestly non-disposable`() {
+        val linkName = "link"
+        youTrackDb.withSession { session ->
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+        }
+        val source = youTrackDb.withStoreTx { tx ->
+            val source = tx.createIssue("source")
+            source.addLink(linkName, tx.createIssue("target"))
+            source
+        }
+
+        youTrackDb.withStoreTx {
+            val links = source.getLinks(linkName)
+            assertFalse(links.iterator().shouldBeDisposed())
+            assertFalse(links.iterator().dispose())
         }
     }
 

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBFindLinksTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBFindLinksTest.kt
@@ -169,6 +169,55 @@ class YTDBFindLinksTest : OTestMixin {
         }
     }
 
+    /**
+     * XD-1292 / audit #7 — `findLinks` must normalise its `entities` operand with `unwrap()` before
+     * casting it, so a link read can be passed as the operand.
+     *
+     * **The operand must be non-empty or the row is vacuous.** The naive choice — a *board's*
+     * `getLinks(ON_BOARD)` — is empty: `ON_BOARD` is Issue→Board and `getLinks` follows outgoing edges
+     * only, so any "doesn't throw" assertion over it would be satisfied by an implementation that
+     * simply dropped the operand. The operand here is `issue1.getLinks(ON_BOARD)` = the boards issue1
+     * is on = `[board1]`, asserted non-empty before use.
+     *
+     * The expectation also discriminates the *operand* rather than merely "no longer throws":
+     * `issue3` is on board2, so a fix that widened the operand into "all boards" would include it.
+     */
+    @Test
+    fun `findLinks accepts a link-read iterable as its entities operand`() {
+        val test = givenIssuesOnBoards()
+
+        withStoreTx { tx ->
+            val boardsOfIssue1 = test.issue1.getLinks(Issues.Links.ON_BOARD)
+            // precondition: a non-empty, non-identity operand (a YTDBVertexEntityIterable)
+            assertEquals(listOf("board1"), boardsOfIssue1.map { it.getProperty("name") })
+
+            val allIssues = YTDBEntityIterable.where(Issues.CLASS, tx.getStore(), GremlinBlock.All)
+            val onBoard1 = allIssues.findLinks(boardsOfIssue1, Issues.Links.ON_BOARD)
+
+            // issue1 and issue2 are on board1; issue3 is on board2 and must be absent
+            assertEquals(setOf("issue1", "issue2"), onBoard1.map { it.getProperty("name") }.toSet())
+        }
+    }
+
+    /**
+     * XD-1292 / B1 — the one `YTDBStoreTransactionImpl.findLinks` overload reachable from the public
+     * session API (`SessionQueryMixin` forwards `entities` unchanged) must normalise its operand too.
+     * Its own `entities.asYTDBIterable()` throws from `YTDBCasts` for a link-read operand today.
+     */
+    @Test
+    fun `transaction findLinks accepts a link-read iterable as its entities operand`() {
+        val test = givenIssuesOnBoards()
+
+        withStoreTx { tx ->
+            val boardsOfIssue1 = test.issue1.getLinks(Issues.Links.ON_BOARD)
+            assertEquals(listOf("board1"), boardsOfIssue1.map { it.getProperty("name") })
+
+            val issues = tx.findLinks(Issues.CLASS, boardsOfIssue1, Issues.Links.ON_BOARD, true)
+
+            assertEquals(setOf("issue1", "issue2"), issues.map { it.getProperty("name") }.toSet())
+        }
+    }
+
     @Test
     fun `findLinks short-circuits on EMPTY`() {
         givenIssuesOnBoards()

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
@@ -665,6 +665,55 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
     }
 
     /**
+     * XD-1292 / audit #10 — a negative argument must clamp, not throw, per Xodus's
+     * `EntityIterableBase` (`skip`: `if (number <= 0 …) return this`; `take`:
+     * `if (number <= 0 …) return EMPTY`). Before the fix both calls threw
+     * `IllegalArgumentException` from the `require(skip >= 0)` / `require(limit >= 0)` guards in
+     * [GremlinBlock], which stay in place as internal invariants.
+     *
+     * **The identity assertions are correct here because this is the raw layer** — `skip` returns the
+     * receiver itself and `take` returns the [YTDBEntityIterable.EMPTY] singleton (`:279-290`), so both
+     * are observable facts rather than incidental allocation. The other levels must assert **contents**
+     * instead, for two different reasons: the in-memory clamp
+     * (`AbstractInMemoryEntityIterable.take`) and the DNQ query layer (`XdQuery.operation`) genuinely
+     * allocate a new iterable / a freshly wrapped query, so identity never holds there; the transient
+     * level (`TransientEntityIterable.skip`/`take`) does return the receiver and this same `EMPTY`
+     * singleton, but its own test still asserts contents on purpose, so that the pin survives any future
+     * decision to allocate. The link-read rows below likewise assert contents: `skip` goes through
+     * `YTDBVertexEntityIterable.skip` → `asQueryIterable().skip(-1)`, whose receiver is the *query*
+     * iterable and not the link iterable, so `=== boardIssues` would be wrong (`take` would in fact
+     * return `EMPTY`, but emptiness is the property under test).
+     *
+     * `iterable take 0` and `iterable skip 0` above are the negative controls: widening `== 0` to
+     * `<= 0` must leave the `0` boundary bit-identical.
+     */
+    @Test
+    fun `negative skip and take match Xodus`() {
+        val test = givenTestCase()
+
+        withStoreTx { tx ->
+            tx.addIssueToBoard(test.issue1, test.board1)
+            tx.addIssueToBoard(test.issue2, test.board1)
+        }
+
+        withStoreTx { tx ->
+            val issues = tx.sort(Issues.CLASS, "name", true)
+
+            assertThat(issues.skip(-1)).isSameInstanceAs(issues)
+            assertNamesExactlyInOrder(issues.skip(-1), "issue1", "issue2", "issue3")
+
+            assertThat(issues.take(-1)).isSameInstanceAs(YTDBEntityIterable.EMPTY)
+            assertThat(issues.take(-1)).isEmpty()
+
+            // a link read reaches the same clamp through asQueryIterable()
+            val boardIssues = test.board1.getLinks(Boards.Links.HAS_ISSUE)
+            assertNamesExactly(boardIssues, "issue1", "issue2")
+            assertNamesExactly(boardIssues.skip(-1), "issue1", "issue2")
+            assertThat(boardIssues.take(-1)).isEmpty()
+        }
+    }
+
+    /**
      * XD-1292 / audit #9 — [jetbrains.exodus.entitystore.EntityIterator.skip] must return the value
      * of `hasNext()`, not `true`.
      *
@@ -718,10 +767,7 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
 
             // Then
             // Note: GremlinBlock.Reverse has BlockType.ORDER, so GremlinQuery.then() routes it through
-            // Order.of() (the `block.type == BlockType.ORDER` branch) before ever reaching the
-            // `block is GremlinBlock.Reverse` check. This means the entire `block is GremlinBlock.Reverse`
-            // branch — including the `is SortBy -> reverseOrder()` case — is dead code. Even a SortBy
-            // query gets fold().reverse().unfold() appended rather than having its sort direction flipped.
+            // Order.of() — even a SortBy query gets fold().reverse().unfold() appended.
             checkGremlin(
                 reversedByName as YTDBEntityIterable,
                 "g.V().hasLabel(\"Issue\").order().by(__.values(\"name\").count(),Order.desc).by(__.values(\"name\").fold(),Order.asc).fold().reverse().unfold()"

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
@@ -663,6 +663,45 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
         }
     }
 
+    /**
+     * XD-1292 / audit #9 — [jetbrains.exodus.entitystore.EntityIterator.skip] must return the value
+     * of `hasNext()`, not `true`.
+     *
+     * **Every assertion obtains a FRESH `iterator()`, and that is load-bearing, not hygiene:** after
+     * the fix `skip` ends in `hasNext()`, and `YTDBEntityIterator.hasNext()` **disposes** the
+     * traversal on exhaustion. On one shared iterator the `skip(3)` row would leave a disposed,
+     * fully-consumed iterator, so a following `skip(2)` would observe `false` instead of `true` — the
+     * row that actually discriminates the defect would look wrong for an unrelated reason. Do not
+     * "simplify" this back to a single shared iterator.
+     */
+    @Test
+    fun `iterator skip returns hasNext`() {
+        givenTestCase()
+
+        withStoreTx { tx ->
+            val issues = YTDBEntityIterable.where(Issues.CLASS, tx.getStore(), GremlinBlock.All)
+            assertEquals(3L, issues.size())
+
+            // skipping to exact exhaustion: nothing is left
+            assertEquals(false, issues.iterator().skip(3))
+            // one element left
+            assertEquals(true, issues.iterator().skip(2))
+            // skipping past the end: nothing is left
+            assertEquals(false, issues.iterator().skip(4))
+
+            // negative n is a no-op: nothing is consumed, and the answer is hasNext()
+            val nonEmpty = issues.iterator()
+            assertEquals(true, nonEmpty.skip(-1))
+            assertEquals(3, nonEmpty.asSequence().count())
+
+            // ... which on an EMPTY iterable is false, where it used to be an unconditional true
+            val empty = YTDBEntityIterable.where(Issues.CLASS, tx.getStore(), GremlinBlock.PropNull("name"))
+            assertEquals(0L, empty.size())
+            assertEquals(false, empty.iterator().skip(-1))
+            assertEquals(false, empty.iterator().skip(0))
+        }
+    }
+
     @Test
     fun `iterable sort and reverse`() {
         // Given

--- a/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
+++ b/dnq-entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBGremlinEntityIterableTest.kt
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.translator.GroovyTranslato
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class YTDBGremlinEntityIterableTest : OTestMixin {
 
@@ -1240,6 +1241,88 @@ class YTDBGremlinEntityIterableTest : OTestMixin {
                 """g.V().has("name",P.within(["board1", "board2"])).hasLabel("Board").out("HasIssue_link").dedup()"""
             )
             assertNamesExactly(issues, "issue1", "issue2")
+        }
+    }
+
+    /**
+     * XD-1292 / audit #7 — the four binary operators must normalise the right operand with `unwrap()`
+     * before casting it, so a link read (a `YTDBVertexEntityIterable`, which implements only
+     * `EntityIterable`) can be combined with a query iterable. All four throw
+     * `IllegalArgumentException("Only GremlinEntityIterable is supported, but was
+     * YTDBVertexEntityIterable")` from `YTDBCasts` today.
+     *
+     * **The operand must really contain elements.** The naive choice — a *board's*
+     * `getLinks(ON_BOARD)` — is empty, because `ON_BOARD` is Issue→Board and `getLinks` follows
+     * outgoing edges only; every assertion over it would be satisfied by dropping the operand
+     * entirely. Here the operand is `issue1.getLinks(ON_BOARD)` = `[board1]`, asserted non-empty first.
+     *
+     * Content only, never order: optimiser rule O3 strips the right operand's sort for
+     * intersect/difference and both sorts for union, so the link order does not survive a binary op.
+     */
+    @Test
+    fun `binary ops accept a link-read iterable as operand`() {
+        val test = givenTestCase()
+        withStoreTx { tx ->
+            tx.addIssueToBoard(test.issue1, test.board1)
+            tx.addIssueToBoard(test.issue2, test.board1)
+            tx.addIssueToBoard(test.issue3, test.board2)
+        }
+
+        withStoreTx { tx ->
+            val boardsOfIssue1 = test.issue1.getLinks(Issues.Links.ON_BOARD)
+            // precondition: a non-empty, non-identity operand
+            assertEquals(listOf("board1"), boardsOfIssue1.map { it.getProperty("name") })
+
+            val allBoards = tx.getAll(Boards.CLASS)
+            assertNamesExactly(allBoards, "board1", "board2", "board3")
+
+            assertNamesExactly(allBoards.intersect(boardsOfIssue1), "board1")
+            assertNamesExactly(allBoards.union(boardsOfIssue1), "board1", "board2", "board3")
+            assertNamesExactly(allBoards.minus(boardsOfIssue1), "board2", "board3")
+            assertNamesExactly(
+                allBoards.concat(boardsOfIssue1),
+                "board1", "board2", "board3", "board1"
+            )
+            assertNamesExactly(allBoards.intersectSavingOrder(boardsOfIssue1), "board1")
+        }
+    }
+
+    /**
+     * XD-1292 / BG15 — the accepted risk of #7, pinned so it is visible rather than latent.
+     *
+     * Normalising the operand newly routes a `YTDBVertexEntityIterable` into
+     * `requirePolymorphicMatch`, and a link read's unwrapped form carries a **hardcoded**
+     * `polymorphic = true` (`YTDBVertexEntityIterable.asQueryIterable()` calls the
+     * `YTDBEntityIterable.query` factory, whose flag defaults to `true`; there is no source for a
+     * per-link flag). So a **non-polymorphic** receiver combined with a link read now fails the flag
+     * check instead of the cast.
+     *
+     * This is not a regression: the same input already threw `IllegalArgumentException` from
+     * `YTDBCasts` before the change, so no working input starts failing — only the message changes.
+     * Threading a flag through `asQueryIterable()` is out of scope. A `polymorphic = false` receiver
+     * *is* reachable from production — `XdEntityType.all(polymorphic = false)` and
+     * `YTDBStoreTransaction.getAll(type, polymorphic = false)` are public — but combining one with a
+     * link read has never worked: a link read is a `YTDBVertexEntityIterable`, which is not a
+     * [YTDBEntityIterable], so the pre-change cast rejected it too.
+     */
+    @Test
+    fun `a non-polymorphic receiver cannot be combined with a link read`() {
+        val test = givenTestCase()
+        withStoreTx { tx -> tx.addIssueToBoard(test.issue1, test.board1) }
+
+        withStoreTx { tx ->
+            val boardsOfIssue1 = test.issue1.getLinks(Issues.Links.ON_BOARD)
+            val nonPolymorphic = YTDBEntityIterable.where(
+                Boards.CLASS, tx.getStore(), GremlinBlock.All, polymorphic = false
+            )
+
+            val e = assertFailsWith<IllegalArgumentException> {
+                nonPolymorphic.intersect(boardsOfIssue1)
+            }
+            assertThat(e).hasMessageThat().contains("Both operands must have the same polymorphic flag")
+
+            // ... while a polymorphic receiver - the only match for a link read's hardcoded true - works
+            assertNamesExactly(tx.getAll(Boards.CLASS).intersect(boardsOfIssue1), "board1")
         }
     }
 

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/InMemoryEntityIterable.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/InMemoryEntityIterable.kt
@@ -58,12 +58,46 @@ abstract class AbstractInMemoryEntityIterable(
         return iterable.count().toLong()
     }
 
+    /**
+     * Compares [EntityId]s, analogous to Xodus's `EntityIterableBase.indexOfImpl`.
+     *
+     * The previous `iterable.indexOf(entity)` used `Any.equals`, **argument-first**: Kotlin's
+     * `Iterable<T>.indexOf` evaluates `element == item` (stdlib 2.1.0
+     * `commonMain/generated/_Collections.kt:322-332`, comparison at `:327`), and `List.indexOf`
+     * likewise calls `o.equals(elementData[i])`. So a foreign wrapper carrying a member's id missed on
+     * the argument's own `equals`: `YTDBVertexEntity.equals` bails at `other !is YTDBEntity` /
+     * `javaClass != other.javaClass`, and `TransientEntityImpl.equals` at `other !is TransientEntity`.
+     * Id comparison is safe across implementations: `RIDEntityId.equals` tests `(typeId, localId)`
+     * against any [EntityId]. Complexity is unchanged — both forms are linear scans over [iterable].
+     */
     override fun indexOf(entity: Entity): Int {
-        return iterable.indexOf(entity)
+        val id = entity.id
+        var i = 0
+        for (e in iterable) {
+            if (e.id == id) return i
+            ++i
+        }
+        return -1
     }
 
+    /**
+     * Per the `EntityIterable.contains` contract, "just returns `indexOf(entity) != -1`" — but keeping
+     * the backing collection's own membership test as a fast path where it is better than linear.
+     *
+     * [iterable] really can be hash-backed on a production path: `QueryEngine.inMemoryUnion` builds it
+     * with Kotlin's `union`, i.e. a `LinkedHashSet`, and `Set.asIterable()` is the identity, so
+     * `x in (qA union qB)` (via `XdQuery.contains` → `PersistentEntityIterableWrapper.contains`) used to
+     * be an O(1) hash probe. Dropping that would regress it to O(n) for hits *and* misses.
+     *
+     * The probe can only produce **false negatives** — object/hash equality is strictly narrower than
+     * id equality, and a positive means some element `equals` (or, for a sorted set, compares equal to)
+     * the argument, which implies equal ids — so a miss falls through to the id scan, which is what
+     * fixes the cross-wrapper-type case. The gate is `Set` rather than `Collection` on purpose: for a
+     * `List` the old `contains` was already O(n), so a fast path there would only add a second scan.
+     */
     override fun contains(entity: Entity): Boolean {
-        return iterable.contains(entity)
+        if (iterable is Set<*> && iterable.contains(entity)) return true
+        return indexOf(entity) != -1
     }
 
     override fun intersect(right: EntityIterable): EntityIterable {
@@ -154,6 +188,11 @@ internal class InMemoryEntityIterator(val iterator: Iterator<Entity>) : EntityIt
 
     override fun next() = iterator.next()
 
+    /**
+     * Skips up to [number] entities and returns the value of [hasNext], per the
+     * `EntityIterator.skip` contract ("Skips specified number of entities and returns the value of
+     * `hasNext()`") — not "did I manage to skip that many".
+     */
     override fun skip(number: Int): Boolean {
         for (i in 0..<number) {
             if (iterator.hasNext()) {
@@ -162,14 +201,20 @@ internal class InMemoryEntityIterator(val iterator: Iterator<Entity>) : EntityIt
                 return false
             }
         }
-        return true
+        return iterator.hasNext()
     }
 
     override fun nextId(): EntityId {
         return next().id
     }
 
-    override fun dispose() = true
+    /**
+     * Nothing is held — [iterator] is a plain `Iterator` over an already-materialised `Iterable` — so
+     * nothing can be released, and `dispose()`'s contract is "`true` if the `EntityIterator` was
+     * actually disposed". Kept as `false` rather than the throwing form used by the two transient
+     * iterators, because `dispose()` is routinely called in `finally` blocks that ignore its answer.
+     */
+    override fun dispose() = false
 
     override fun shouldBeDisposed() = false
 

--- a/dnq-query/src/main/kotlin/jetbrains/exodus/query/InMemoryEntityIterable.kt
+++ b/dnq-query/src/main/kotlin/jetbrains/exodus/query/InMemoryEntityIterable.kt
@@ -130,7 +130,19 @@ abstract class AbstractInMemoryEntityIterable(
         return InMemoryEntityIterable(skipIterator, txn, queryEngine)
     }
 
+    /**
+     * Kotlin's `Iterable.take` opens with `require(n >= 0)`, so a negative [number] would throw where
+     * Xodus's `EntityIterableBase.take` returns the empty iterable. Clamp negatives only: `take(0)`
+     * already goes through `iterable.take(0)` == `emptyList()`.
+     *
+     * [skip] needs no such guard — its `InMemoryEntityIterator.skip` loops over `0..<number`, an empty
+     * range for negatives, so every element survives. That is **content**-equivalent to Xodus's
+     * `skip(n <= 0)`, not identical to it: Xodus returns the receiver, whereas [skip] here always
+     * allocates a new iterable around a re-iterating `Iterable {}`. The difference is recorded as an
+     * accepted risk (AR1) rather than fixed — nothing compares a `skip` result against its own receiver.
+     */
     override fun take(number: Int): EntityIterable {
+        if (number < 0) return InMemoryEntityIterable(emptyList(), txn, queryEngine)
         return InMemoryEntityIterable(iterable.take(number), txn, queryEngine)
     }
 

--- a/dnq-query/src/test/kotlin/jetbrains/exodus/query/InMemoryEntityIterableContractTest.kt
+++ b/dnq-query/src/test/kotlin/jetbrains/exodus/query/InMemoryEntityIterableContractTest.kt
@@ -27,8 +27,9 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
- * XD-1292 / audit #11-A and #21-A — the two contract defects of `dnq-query`'s in-memory iterable that
- * are byte-for-byte copies of #11 and #21 one module away.
+ * XD-1292 / audit #11-A, #21-A and B2 — the contract defects of `dnq-query`'s in-memory iterable;
+ * #11-A and #21-A are byte-for-byte copies of #11 and #21 one module away, B2 is #10's in-memory
+ * mirror.
  */
 class InMemoryEntityIterableContractTest : OTestMixin {
 
@@ -142,6 +143,40 @@ class InMemoryEntityIterableContractTest : OTestMixin {
 
             assertFalse(iterable.contains(fresh))
             assertEquals(-1, iterable.indexOf(fresh))
+        }
+    }
+
+    /**
+     * B2 — #10's in-memory mirror. `AbstractInMemoryEntityIterable.take` delegates to Kotlin's
+     * `Iterable.take`, whose `require(n >= 0)` threw `IllegalArgumentException` for a negative
+     * argument, where Xodus's `EntityIterableBase.take` returns the empty iterable. Only the `take`
+     * half needed the clamp: `skip` routes through `InMemoryEntityIterator.skip`, whose `0..<number`
+     * range is empty for negatives, so it already preserved every element — the third row is that
+     * preservation control and passes before and after the fix.
+     *
+     * **Contents/emptiness only, never identity** (TQ35/TQ38): the clamp returns a *new*
+     * `InMemoryEntityIterable(emptyList(), …)`, not `YTDBEntityIterable.EMPTY`, and the class overrides
+     * no `equals`; `skip` likewise always builds a new iterable, so `=== iterable` never held.
+     */
+    @Test
+    fun `in-memory take clamps negative arguments and skip preserves contents`() {
+        val test = givenTestCase()
+
+        withStoreTx { tx ->
+            val engine = QueryEngine(null, youTrackDb.store)
+            val members: List<Entity> = listOf(test.issue1, test.issue2, test.issue3)
+            val iterable = InMemoryEntityIterable(members, tx, engine)
+
+            // the defect: this call threw IllegalArgumentException before the clamp
+            assertTrue(iterable.take(-1).isEmpty)
+            assertEquals(emptyList(), iterable.take(-1).toList())
+
+            // `0` boundary control - untouched path, `Iterable.take(0)` is already emptyList()
+            assertTrue(iterable.take(0).isEmpty)
+            assertEquals(emptyList(), iterable.take(0).toList())
+
+            // preservation control - already contract-correct, must stay so
+            assertEquals(members.map { it.id }, iterable.skip(-1).toList().map { it.id })
         }
     }
 

--- a/dnq-query/src/test/kotlin/jetbrains/exodus/query/InMemoryEntityIterableContractTest.kt
+++ b/dnq-query/src/test/kotlin/jetbrains/exodus/query/InMemoryEntityIterableContractTest.kt
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.exodus.query
+
+import io.mockk.every
+import io.mockk.mockk
+import jetbrains.exodus.entitystore.Entity
+import jetbrains.exodus.entitystore.youtrackdb.testutil.*
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * XD-1292 / audit #11-A and #21-A — the two contract defects of `dnq-query`'s in-memory iterable that
+ * are byte-for-byte copies of #11 and #21 one module away.
+ */
+class InMemoryEntityIterableContractTest : OTestMixin {
+
+    @Rule
+    @JvmField
+    val orientDbRule = InMemoryYouTrackDB()
+
+    override val youTrackDb = orientDbRule
+
+    /**
+     * #11-A — `AbstractInMemoryEntityIterable.indexOf`/`contains` delegated to the Kotlin `Iterable`
+     * extensions, i.e. to `Any.equals`, so a foreign `Entity` implementation carrying a member's id
+     * missed. Must compare `EntityId`s.
+     *
+     * Three guards, all mandatory:
+     *  1. the positive target sits at a **non-zero** index, asserted exactly;
+     *  2. a **cross-type collision** control (`localId` sequences are per class, so `board3` really
+     *     shares `issue3`'s `localId`);
+     *  3. an **absent** same-type entity control.
+     */
+    @Test
+    fun `in-memory indexOf and contains compare entity ids`() {
+        val test = givenTestCase()
+        val absentIssue = youTrackDb.createIssue("absent")
+
+        withStoreTx { tx ->
+            val engine = QueryEngine(null, youTrackDb.store)
+            val members: List<Entity> = listOf(test.issue1, test.issue2, test.issue3)
+            val iterable = InMemoryEntityIterable(members, tx, engine)
+
+            // GUARD 1 - positive row on a NON-FIRST element, exact index asserted.
+            val targetIndex = members.size - 1
+            val target = members[targetIndex]
+            assertTrue(targetIndex > 0, "the positive row must not target index 0")
+            val foreignWrapper = mockk<Entity> { every { id } returns target.id }
+            assertEquals(targetIndex, iterable.indexOf(foreignWrapper))
+            assertTrue(iterable.contains(foreignWrapper))
+
+            // GUARD 2 - cross-type collision: same localId, different typeId, must NOT be found.
+            val collider = listOf(test.board1, test.board2, test.board3)
+                .first { it.id.localId == target.id.localId }
+            assertNotEquals(collider.id.typeId, target.id.typeId, "collider must be of another type")
+            assertEquals(collider.id.localId, target.id.localId, "collider must share the localId")
+            assertFalse(iterable.contains(collider))
+            assertEquals(-1, iterable.indexOf(collider))
+
+            // GUARD 3 - an absent entity of the same type.
+            assertFalse(iterable.contains(absentIssue))
+            assertEquals(-1, iterable.indexOf(absentIssue))
+        }
+    }
+
+    /**
+     * PF1 — the `contains` fast path must survive, and must not shadow the id-based answer.
+     *
+     * `QueryEngine.inMemoryUnion` builds the backing iterable with Kotlin's `union`, i.e. a
+     * `LinkedHashSet`, and `Set.asIterable()` is the identity — so a real production receiver is
+     * hash-backed and its membership test must stay O(1). This row pins both halves: the hash probe
+     * still answers same-object hits, and a *foreign wrapper* (which the probe necessarily misses,
+     * since object equality is narrower than id equality) still falls through to the id scan.
+     */
+    @Test
+    fun `in-memory contains keeps the hash fast path without losing the id fallback`() {
+        val test = givenTestCase()
+        val absentIssue = youTrackDb.createIssue("absent")
+
+        withStoreTx { tx ->
+            val engine = QueryEngine(null, youTrackDb.store)
+            // exactly the shape inMemoryUnion produces
+            val backing: Set<Entity> = linkedSetOf(test.issue1, test.issue2, test.issue3)
+            val iterable = InMemoryEntityIterable(backing, tx, engine)
+
+            // the fast path itself
+            assertTrue(iterable.contains(test.issue3))
+            assertFalse(iterable.contains(absentIssue))
+
+            // ... and the id fallback behind it, which the hash probe cannot answer
+            val foreignWrapper = mockk<Entity> { every { id } returns test.issue3.id }
+            assertTrue(iterable.contains(foreignWrapper))
+            assertEquals(2, iterable.indexOf(foreignWrapper))
+
+            // cross-type collision must still be rejected by both paths
+            val collider = listOf(test.board1, test.board2, test.board3)
+                .first { it.id.localId == test.issue3.id.localId }
+            assertFalse(iterable.contains(collider))
+        }
+    }
+
+    /**
+     * BG33 — the rewritten `indexOf`/`contains` read `entity.id` eagerly, where the old
+     * `equals`-based comparison never touched the argument's id. `TransientEntityImpl.getId()` throws
+     * `IllegalStateException("Cannot get wrapped persistent entity")` when no persistent entity is
+     * bound, so the question is whether a caller can now get an exception where it used to get
+     * `false`. This row pins the contract answer for the closest reachable case in this module: a
+     * brand-new, not-yet-flushed entity used as the argument.
+     *
+     * Verdict: it does not throw — `TransientEntityImpl.id` is assigned by every constructor before
+     * the object is published and is never reset to `null`. And an eager `entity.getId()` is what the
+     * contract authority itself does: Xodus's `EntityIterableBase.indexOf` (`:219`) and `contains`
+     * (`:230`) both read it unguarded, so swallowing an id-access failure here would be a divergence
+     * from the reference, not a repair.
+     */
+    @Test
+    fun `in-memory contains answers false for a brand new unflushed argument`() {
+        val test = givenTestCase()
+
+        withStoreTx { tx ->
+            val engine = QueryEngine(null, youTrackDb.store)
+            val iterable = InMemoryEntityIterable(listOf(test.issue1, test.issue2), tx, engine)
+            val fresh = tx.createIssue("created-in-this-tx-and-not-flushed")
+
+            assertFalse(iterable.contains(fresh))
+            assertEquals(-1, iterable.indexOf(fresh))
+        }
+    }
+
+    /**
+     * #21-A — `InMemoryEntityIterator.dispose()` claimed `true` while holding nothing and while
+     * `shouldBeDisposed()` said `false`. Both halves are asserted so the pair cannot drift apart.
+     *
+     * Deliberately kept as `false`/`false` rather than the throwing form used by the two transient
+     * iterators: `dispose()` is routinely called in `finally` blocks that ignore its answer.
+     */
+    @Test
+    fun `in-memory iterator is honestly non-disposable`() {
+        val test = givenTestCase()
+
+        withStoreTx { tx ->
+            val engine = QueryEngine(null, youTrackDb.store)
+            val iterable = InMemoryEntityIterable(listOf(test.issue1, test.issue2), tx, engine)
+
+            assertFalse(iterable.iterator().shouldBeDisposed())
+            assertFalse(iterable.iterator().dispose())
+        }
+    }
+}

--- a/dnq-query/src/test/kotlin/jetbrains/exodus/query/InMemoryEntityIteratorSkipTest.kt
+++ b/dnq-query/src/test/kotlin/jetbrains/exodus/query/InMemoryEntityIteratorSkipTest.kt
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.exodus.query
+
+import jetbrains.exodus.entitystore.Entity
+import jetbrains.exodus.entitystore.youtrackdb.testutil.InMemoryYouTrackDB
+import jetbrains.exodus.entitystore.youtrackdb.testutil.OTestMixin
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * XD-1292 / audit #9-B — `InMemoryEntityIterator.skip` (the iterator behind every in-memory query
+ * result in `dnq-query`) repeats #9's defect verbatim: it returns `true` regardless of whether
+ * anything is left. Contract: `skip(n)` returns the value of `hasNext()`.
+ *
+ * **A FRESH `iterator()` per assertion** — every row is a statement about the *initial* iterator
+ * state, so a shared iterator would make later rows depend on how much earlier rows consumed.
+ */
+class InMemoryEntityIteratorSkipTest : OTestMixin {
+
+    @Rule
+    @JvmField
+    val orientDbRule = InMemoryYouTrackDB()
+
+    override val youTrackDb = orientDbRule
+
+    @Test
+    fun `in-memory iterator skip returns hasNext`() {
+        val test = givenTestCase()
+
+        withStoreTx { tx ->
+            val engine = QueryEngine(null, youTrackDb.store)
+            val entities: List<Entity> = listOf(test.issue1, test.issue2, test.issue3)
+
+            fun iter() = InMemoryEntityIterable(entities, tx, engine).iterator()
+
+            // skipping to exact exhaustion: nothing is left
+            assertFalse(iter().skip(3))
+            // one element left
+            assertTrue(iter().skip(2))
+            // skipping past the end: nothing is left
+            assertFalse(iter().skip(4))
+
+            // negative n is a no-op: nothing is consumed, and the answer is hasNext()
+            val nonEmpty = iter()
+            assertTrue(nonEmpty.skip(-1))
+            assertEquals(test.issue1.id, nonEmpty.next().id)
+
+            // ... which on an EMPTY iterable is false, where it used to be an unconditional true
+            fun emptyIter() = InMemoryEntityIterable(emptyList(), tx, engine).iterator()
+            assertFalse(emptyIter().skip(-1))
+            assertFalse(emptyIter().skip(0))
+        }
+    }
+}

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/AddedOrRemovedLinksFromSetTransientEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/AddedOrRemovedLinksFromSetTransientEntityIterable.kt
@@ -78,6 +78,13 @@ internal open class AddedOrRemovedLinksFromSetTransientEntityIterable(
 
             override fun nextId() = next().id
 
+            /**
+             * Skips up to [number] entities and returns the value of [hasNext], per the
+             * `EntityIterator.skip` contract. The walk itself was already correct (it consumes
+             * through the multi-link [hasNext], which rolls over to the next link name, and a
+             * non-positive [number] is a no-op because the guard is `> 0`) — only the terminal
+             * answer was wrong. Correct sibling in this package: `TransientEntityIterator.skip`.
+             */
             override fun skip(number: Int): Boolean {
                 var itemsToSkipLeft = number
                 while (itemsToSkipLeft > 0) {
@@ -88,7 +95,7 @@ internal open class AddedOrRemovedLinksFromSetTransientEntityIterable(
                         return false
                     }
                 }
-                return true
+                return hasNext()
             }
 
             override fun shouldBeDisposed() = false

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIterableWrapper.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIterableWrapper.kt
@@ -86,8 +86,13 @@ open class PersistentEntityIterableWrapper(
         return wrappedIterable.take(number)
     }
 
+    /**
+     * Normalises the operand like the five binary operators above already do. The raw layer now
+     * unwraps its operand as well, so this is for consistency with those siblings and to avoid
+     * handing a doubly-wrapped operand down.
+     */
     override fun findLinks(entities: EntityIterable, linkName: String): EntityIterable {
-        return wrappedIterable.findLinks(entities, linkName)
+        return wrappedIterable.findLinks(entities.unwrap(), linkName)
     }
 
     override fun distinct(): EntityIterable {

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIteratorWrapper.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/PersistentEntityIteratorWrapper.kt
@@ -68,6 +68,14 @@ class PersistentEntityIteratorWrapper(
         return source.dispose()
     }
 
+    /**
+     * Skips up to [number] entities and returns the value of [hasNext], per the
+     * `EntityIterator.skip` contract.
+     *
+     * The terminal answer must go through [initCurrent] (i.e. this iterator's own [hasNext]) and
+     * **not** `source.hasNext()`: this iterator filters out entities the transient changes tracker
+     * knows as removed, so `source` can still have elements while this iterator is exhausted.
+     */
     override fun skip(number: Int): Boolean {
 
         repeat(number) {
@@ -76,7 +84,7 @@ class PersistentEntityIteratorWrapper(
             }
             consumeCurrent()
         }
-        return true
+        return initCurrent() != null
     }
 
     override fun shouldBeDisposed(): Boolean {

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/SnapshotEntityIterable.kt
@@ -49,7 +49,7 @@ internal class SnapshotEntityIterable(
         wrap(original.minus(getOriginal(right)))
 
     override fun concat(right: EntityIterable): EntityIterable =
-        wrap(original.minus(getOriginal(right)))
+        wrap(original.concat(getOriginal(right)))
 
     override fun skip(number: Int): EntityIterable = wrap(original.skip(number))
 

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterable.kt
@@ -107,8 +107,13 @@ open class TransientEntityIterable(protected val values: Set<TransientEntity>) :
         return TransientEntityIterable(values + right.values)
     }
 
+    /**
+     * `Sequence.drop` opens with `require(n >= 0)`, so a negative [number] would throw where Xodus's
+     * `EntityIterableBase.skip` returns the receiver. Widening the existing `== 0` guard to `<= 0` is a
+     * negative-only change: the guard already returned `this` at `0`.
+     */
     override fun skip(number: Int): EntityIterable {
-        if (number == 0) return this
+        if (number <= 0) return this
 
         return TransientEntityIterable(
                 values.asSequence()
@@ -117,8 +122,13 @@ open class TransientEntityIterable(protected val values: Set<TransientEntity>) :
         )
     }
 
+    /**
+     * `Sequence.take` opens with `require(n >= 0)`, so a negative [number] would throw where Xodus's
+     * `EntityIterableBase.take` returns the empty iterable. As in [skip], widening `== 0` to `<= 0`
+     * changes nothing at `0`.
+     */
     override fun take(number: Int): EntityIterable {
-        if (number == 0) return YTDBEntityIterable.EMPTY
+        if (number <= 0) return YTDBEntityIterable.EMPTY
 
         return TransientEntityIterable(
                 values.asSequence()

--- a/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterable.kt
+++ b/dnq-transient-store/src/main/kotlin/com/jetbrains/teamsys/dnq/database/TransientEntityIterable.kt
@@ -52,9 +52,38 @@ open class TransientEntityIterable(protected val values: Set<TransientEntity>) :
         return values.size.toLong()
     }
 
-    override fun indexOf(entity: Entity) = values.indexOf(entity)
+    /**
+     * Compares [jetbrains.exodus.entitystore.EntityId]s, analogous to Xodus's
+     * `EntityIterableBase.indexOfImpl`.
+     *
+     * The previous `values.indexOf(entity)` missed whenever the argument was the *persistent* entity
+     * for the same id — which is exactly what `XdQuery.contains`/`indexOf` can hand down. The
+     * mechanism is **argument-first**: [values] is a `Set`, not a `List`, so Kotlin's
+     * `Iterable<T>.indexOf` falls through to its scan, which evaluates `element == item`
+     * (stdlib 2.1.0 `commonMain/generated/_Collections.kt:322-332`, the comparison at `:327`) — i.e.
+     * it runs the *argument's* `equals`. For a `YTDBVertexEntity` argument that is
+     * `YTDBVertexEntity.equals`, which returns `false` at its `other !is YTDBEntity` check because
+     * `TransientEntity` extends `Entity`, not `YTDBEntity`; the elements' `TransientEntityImpl.equals`
+     * is never reached. Id comparison is safe across implementations: `RIDEntityId.equals` tests
+     * `(typeId, localId)` against any `EntityId`.
+     *
+     * Note the index of a `Set`-backed iterable has always been iteration-order dependent; that is
+     * unchanged.
+     */
+    override fun indexOf(entity: Entity): Int {
+        val id = entity.id
+        return values.indexOfFirst { it.id == id }
+    }
 
-    operator override fun contains(entity: Entity) = values.contains(entity)
+    /**
+     * `indexOf(entity) != -1`, but keeping the O(1) hash lookup as a fast path: [values] is a `Set`,
+     * so the common same-type case must not become a linear scan. The two are consistent —
+     * `TransientEntityImpl.equals` implies equal ids — and the hash lookup cannot succeed for a
+     * foreign wrapper anyway (`TransientEntityImpl.hashCode` is `id.hashCode() +
+     * persistentStore.hashCode()`, `YTDBVertexEntity.hashCode` is `id.hashCode()`).
+     */
+    operator override fun contains(entity: Entity) =
+            values.contains(entity) || values.any { it.id == entity.id }
 
     override fun intersect(right: EntityIterable): EntityIterable =
             throw UnsupportedOperationException("Not supported by TransientEntityIterable")

--- a/dnq/src/test/kotlin/kotlinx/dnq/IteratorSkipContractTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/IteratorSkipContractTest.kt
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import com.jetbrains.teamsys.dnq.database.PersistentEntityIteratorWrapper
+import jetbrains.exodus.database.TransientEntity
+import jetbrains.exodus.entitystore.Entity
+import jetbrains.exodus.entitystore.EntityIterable
+import jetbrains.exodus.entitystore.iterate.EntityIteratorWithPropId
+import kotlinx.dnq.link.OnDeletePolicy
+import kotlinx.dnq.events.Foo
+import kotlinx.dnq.events.Goo
+import kotlinx.dnq.query.XdQuery
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * XD-1292 / audit #9-A and #9-C — [jetbrains.exodus.entitystore.EntityIterator.skip] must return the
+ * value of `hasNext()` ("is anything left"), not `true` ("I managed to skip that many").
+ *
+ * Both sites live in `dnq-transient-store`, which has no test source set, so their tests live here
+ * and use `dnq`'s own fixtures.
+ *
+ * **A FRESH `iterator()` per assertion, everywhere.** Every row is a statement about the *initial*
+ * iterator state; after the fix `skip` ends in `hasNext()`, which on some implementations has side
+ * effects (disposal), so a shared iterator would make later rows depend on earlier ones.
+ */
+class IteratorSkipContractTest : DBTest() {
+
+    /**
+     * A two-link type, needed for the multi-link-name rollover row of #9-C. `dnq`'s shared `events`
+     * model only has the single-link `Goo.content`, and the one existing multi-link fixture
+     * (`TransientEntityLinksFromSetTest.testAll`) is `@Ignore`d on XD-1118, so this test brings its
+     * own.
+     */
+    class Node(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<Node>()
+
+        var name by xdStringProp()
+        val alpha by xdLink0_N(Node, dbPropertyName = "alpha", onTargetDelete = OnDeletePolicy.CLEAR)
+        val beta by xdLink0_N(Node, dbPropertyName = "beta", onTargetDelete = OnDeletePolicy.CLEAR)
+    }
+
+    override fun registerEntityTypes() {
+        XdModel.registerNodes(User, RootGroup, NestedGroup, Image, Contact, Team, Fellow, Foo, Goo, Node)
+    }
+
+    private fun XdQuery<*>.entityIterableOrThrow() = entityIterable as EntityIterable
+
+    /**
+     * #9-A — `PersistentEntityIteratorWrapper.skip`. This is the iterator every DNQ caller actually
+     * receives (`PersistentEntityIterableWrapper.iterator()` constructs it), so fixing the raw
+     * `YTDBEntityIterator` alone leaves the contract violation observable at the DNQ layer.
+     */
+    @Test
+    fun `PersistentEntityIteratorWrapper skip returns hasNext`() {
+        transactional {
+            repeat(3) { i -> User.new { login = "u$i"; skill = i } }
+        }
+        transactional {
+            val users = User.all().entityIterableOrThrow()
+            // Precondition: we really are exercising the transient-store wrapper, not the raw iterator.
+            assertTrue(users.iterator() is PersistentEntityIteratorWrapper)
+            assertEquals(3L, users.size())
+
+            // skipping to exact exhaustion: nothing is left
+            assertFalse(users.iterator().skip(3))
+            // one element left
+            assertTrue(users.iterator().skip(2))
+            // skipping past the end: nothing is left
+            assertFalse(users.iterator().skip(4))
+
+            // negative n is a no-op: nothing is consumed, and the answer is hasNext()
+            val nonEmpty = users.iterator()
+            assertTrue(nonEmpty.skip(-1))
+            assertEquals(3, nonEmpty.asSequence().count())
+
+            // ... which on an EMPTY iterable is false, where it used to be an unconditional true
+            val empty = Image.all().entityIterableOrThrow()
+            assertEquals(0L, empty.size())
+            assertFalse(empty.iterator().skip(-1))
+            assertFalse(empty.iterator().skip(0))
+        }
+    }
+
+    /**
+     * #9-A, the row that distinguishes a fix routed through the class's own `initCurrent()` from one
+     * routed through `source.hasNext()`: this iterator filters out entities the transient changes
+     * tracker knows as removed, so `source` can still have elements while this iterator is exhausted.
+     *
+     * **The removed entity must be the LAST one in iteration order.** Deleting the first one is not
+     * discriminating: `source` and this iterator then run out at the same moment, and
+     * `return source.hasNext()` gives the same answer as `return initCurrent() != null` on every row.
+     * With the last one removed there is exactly one position — after two `consumeCurrent()` calls —
+     * where `source` still has an element to yield and this iterator does not.
+     */
+    @Test
+    fun `PersistentEntityIteratorWrapper skip respects removed entities`() {
+        transactional {
+            repeat(3) { i -> User.new { login = "r$i"; skill = i } }
+        }
+        transactional {
+            val all = User.all().entityIterableOrThrow().iterator().asSequence().toList()
+            assertEquals(3, all.size)
+            all.last().delete() // the LAST in iteration order - see the KDoc
+
+            val users = User.all().entityIterableOrThrow()
+            // Precondition: only two survivors as far as THIS iterator is concerned, while the raw
+            // source still yields three, the removed one last.
+            assertEquals(2, users.iterator().let { it.asSequence().count() })
+            assertFalse(users.iterator().skip(2))
+            assertTrue(users.iterator().skip(1))
+        }
+    }
+
+    /**
+     * #9-C — the anonymous `EntityIteratorWithPropId` inside
+     * `AddedOrRemovedLinksFromSetTransientEntityIterable`. Only the `Set<String>` overloads of
+     * `getAddedLinks`/`getRemovedLinks` reach it; the single-name overloads build a
+     * `TransientEntityIterable` whose iterator (`TransientEntityIterator`) is already correct. Hence
+     * the explicit `setOf(...)` call below.
+     *
+     * `dispose()` on this iterator throws by design, so the test must never call it.
+     */
+    @Test
+    fun `AddedOrRemovedLinksFromSet iterator skip returns hasNext`() {
+        val goo = transactional { Goo.new() }
+        transactional {
+            repeat(3) { i -> goo.content.add(Foo.new { intField = i }) }
+
+            val added = (goo.entity as TransientEntity).getAddedLinks(setOf("content"))
+            assertEquals(3L, added.size())
+
+            // skipping to exact exhaustion: nothing is left
+            assertFalse(added.iterator().skip(3))
+            // one element left
+            assertTrue(added.iterator().skip(2))
+            // skipping past the end: nothing is left
+            assertFalse(added.iterator().skip(4))
+
+            // Negative / zero n was already a no-op here (the loop guard is `> 0`) and stays one;
+            // pinned as preserved behaviour, not as a discriminator.
+            assertTrue(added.iterator().skip(-1))
+            assertTrue(added.iterator().skip(0))
+
+            // the empty case: no changed links at all -> YTDBEntityIterable.EMPTY, not this iterator
+            val removed = (goo.entity as TransientEntity).getRemovedLinks(setOf("content"))
+            assertTrue(removed.isEmpty)
+        }
+    }
+
+    /**
+     * #9-C, the row that exercises the class's *defining* behaviour: rolling over from one link name
+     * to the next. The single-link row above is passed by a wrong terminal answer of the form
+     * `currentIterator?.hasNext() ?: hasNext()` — that variant only ever looks at the link currently
+     * being walked, so it reports "nothing left" the moment the first link is exhausted, even though
+     * the next link still has elements.
+     *
+     * Fixture: `alpha` = 1 target, `beta` = 2 targets, queried as `getAddedLinks(setOf("alpha",
+     * "beta"))`. `setOf` preserves insertion order, and the iterator walks `linkNames` in that order,
+     * so the boundary sits exactly after the first element. **`skip(1)` is the discriminating row:**
+     * it lands on the alpha/beta boundary, and the correct terminal `hasNext()` must roll over and
+     * answer `true`.
+     *
+     * `currentLinkName()` after a boundary-crossing `skip` — reported, not silently shipped. It now
+     * names the *upcoming* element's link rather than the last consumed one, because the terminal
+     * `hasNext()` performs the rollover. That is not a new convention: `hasNext()` has always mutated
+     * `currentLinkName`, and `next()` calls `hasNext()` before returning, so the value has only ever
+     * been meaningful *immediately after* `next()` — which is how the sole in-repo reader
+     * (`TransientEntityLinksFromSetTest.toNamesAndEntities`) uses it. `EntityIteratorWithPropId`
+     * documents no contract for it at all (the interface is a bare method). Pinned below so the
+     * behaviour is explicit rather than incidental.
+     */
+    @Test
+    fun `AddedOrRemovedLinksFromSet iterator skip rolls over link names`() {
+        val root = transactional { Node.new { name = "root" } }
+        transactional {
+            root.alpha.add(Node.new { name = "a0" })
+            root.beta.add(Node.new { name = "b0" })
+            root.beta.add(Node.new { name = "b1" })
+
+            val names = setOf("alpha", "beta")
+            val added = (root.entity as TransientEntity).getAddedLinks(names)
+            assertEquals(3L, added.size())
+            // Precondition: the boundary really is after the first element.
+            val walk = added.iterator() as EntityIteratorWithPropId
+            val linkNamesInOrder = mutableListOf<String?>()
+            while (walk.hasNext()) {
+                walk.next()
+                linkNamesInOrder += walk.currentLinkName()
+            }
+            assertEquals(listOf<String?>("alpha", "beta", "beta"), linkNamesInOrder.toList())
+
+            // THE discriminating row: skip(1) exhausts `alpha` and must roll over into `beta`.
+            assertTrue(added.iterator().skip(1))
+            // and the remaining rows still hold across the boundary
+            assertTrue(added.iterator().skip(2))
+            assertFalse(added.iterator().skip(3))
+            assertFalse(added.iterator().skip(4))
+
+            // Pin of the currentLinkName() shift described in the KDoc above.
+            val it1 = added.iterator() as EntityIteratorWithPropId
+            it1.skip(1)
+            assertEquals("beta", it1.currentLinkName(), "skip() looks ahead, so it names the upcoming link")
+            // ... whereas a skip that does not cross a boundary leaves it on the current link
+            val it2 = added.iterator() as EntityIteratorWithPropId
+            it2.skip(2)
+            assertEquals("beta", it2.currentLinkName())
+            // ... and after next() it always names the element just returned.
+            // NB the leading hasNext() is required, and not by this change: next() captures
+            // currentIterator BEFORE calling hasNext(), so a next() on a fresh iterator throws
+            // NoSuchElementException. That is a pre-existing defect of this class, reported
+            // separately and deliberately not fixed here.
+            val it3 = added.iterator() as EntityIteratorWithPropId
+            assertTrue(it3.hasNext())
+            it3.next()
+            assertEquals("alpha", it3.currentLinkName())
+        }
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/OperandNormalisationTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/OperandNormalisationTest.kt
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import com.jetbrains.teamsys.dnq.database.PersistentEntityIterableWrapper
+import jetbrains.exodus.entitystore.EntityIterable
+import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransactionImpl
+import jetbrains.exodus.entitystore.youtrackdb.gremlin.GremlinBlock
+import jetbrains.exodus.entitystore.youtrackdb.iterate.YTDBEntityIterable
+import kotlinx.dnq.query.coverage.Issue
+import kotlinx.dnq.query.coverage.IssueTrackerDataset
+import kotlinx.dnq.query.coverage.Project
+import kotlinx.dnq.query.coverage.Sprint
+import kotlinx.dnq.query.coverage.Tag
+import kotlinx.dnq.query.coverage.Employee
+import kotlinx.dnq.query.coverage.Manager
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * XD-1292 / audit #8 and D5 — operand normalisation at the two sites a `dnq`-module test can reach:
+ * the raw `YTDBEntityIterableImpl` binary operators with a **wrapped EMPTY** operand, and
+ * `PersistentEntityIterableWrapper.findLinks`, which was the one operator in that file not calling
+ * `unwrap()` on its argument.
+ *
+ * `dnq` is the only module that can host these: `dnq-entity-store` and `dnq-query` have no
+ * `dnq-transient-store` dependency, so `PersistentEntityIterableWrapper` is not on their test
+ * classpath. Conversely `dnq` has no test-artifacts dependency on `dnq-entity-store`, so these tests
+ * use `dnq`'s own model (`IssueTrackerModel`) and never `Issues.CLASS` / `OTestMixin`.
+ */
+class OperandNormalisationTest : DBTest() {
+
+    override fun registerEntityTypes() {
+        XdModel.registerNodes(Issue, Project, Sprint, Tag, Employee, Manager)
+    }
+
+    private lateinit var dataset: IssueTrackerDataset
+
+    @Before
+    fun setupDataset() {
+        dataset = IssueTrackerDataset(store)
+    }
+
+    private fun <R> withLowLevelTx(block: (YTDBStoreTransactionImpl) -> R): R =
+        store.persistentStore.computeInTransaction { tx -> block(tx as YTDBStoreTransactionImpl) }
+
+    /**
+     * The `=== EMPTY` fast path must test the **unwrapped** operand. A wrapper around EMPTY is not
+     * identical to EMPTY, so today the guard misses, the cast succeeds (the wrapper *is* a
+     * `YTDBEntityIterable`), `requirePolymorphicMatch` passes (the wrapper delegates `polymorphic`
+     * through `unwrap()`, and EMPTY's is the interface default `true`), and then `rightIterable.query`
+     * reaches `EMPTY.query`, which is `unsupported` → `UnsupportedOperationException("Should never be
+     * called")`.
+     *
+     * **The receiver must be a RAW `YTDBEntityIterableImpl`.** At the DNQ level every receiver is
+     * already a `PersistentEntityIterableWrapper`, whose own operators already do
+     * `wrappedIterable.intersect(right.unwrap())` — so a wrapped EMPTY reaches the raw layer *bare*,
+     * the existing guard fires, and a test written on `Issue.all().entityIterable` would pass today
+     * for the wrong reason. Hence the low-level transaction below.
+     */
+    @Test
+    fun `binary ops accept a wrapped EMPTY operand`() {
+        val wrappedEmpty = transactional {
+            PersistentEntityIterableWrapper(store, YTDBEntityIterable.EMPTY)
+        }
+        // precondition: the wrapper is NOT identical to EMPTY, but unwraps to it
+        assertTrue(wrappedEmpty !== YTDBEntityIterable.EMPTY)
+        assertSame(YTDBEntityIterable.EMPTY, wrappedEmpty.unwrap())
+
+        withLowLevelTx { tx ->
+            val raw = YTDBEntityIterable.where(Issue.entityType, tx.getStore(), GremlinBlock.All)
+            // precondition: a raw impl, not a wrapper, and non-empty so `union` etc. are meaningful
+            assertTrue(raw !is PersistentEntityIterableWrapper)
+            assertTrue(raw.size() > 0)
+
+            assertSame(YTDBEntityIterable.EMPTY, raw.intersect(wrappedEmpty))
+            assertSame(YTDBEntityIterable.EMPTY, raw.intersectSavingOrder(wrappedEmpty))
+            assertSame(raw, raw.union(wrappedEmpty))
+            assertSame(raw, raw.minus(wrappedEmpty))
+            assertSame(raw, raw.concat(wrappedEmpty))
+            assertSame(YTDBEntityIterable.EMPTY, raw.findLinks(wrappedEmpty, "sprint"))
+        }
+    }
+
+    /**
+     * B1's guard half: `YTDBStoreTransactionImpl.findLinks` must also test the unwrapped operand.
+     */
+    @Test
+    fun `transaction findLinks accepts a wrapped EMPTY operand`() {
+        val wrappedEmpty = transactional {
+            PersistentEntityIterableWrapper(store, YTDBEntityIterable.EMPTY)
+        }
+
+        withLowLevelTx { tx ->
+            assertSame(
+                YTDBEntityIterable.EMPTY,
+                tx.findLinks(Issue.entityType, wrappedEmpty, "sprint", true)
+            )
+        }
+    }
+
+    /**
+     * D5 — `PersistentEntityIterableWrapper.findLinks` was the only one of that file's six operand-
+     * taking operators not calling `unwrap()` on its argument, so it handed a wrapper straight down to
+     * the raw layer.
+     *
+     * Pinned with a dependency-free delegating spy; **mockk is deliberately not added to `dnq`**.
+     *
+     * The spy's shape is load-bearing, and two obvious alternatives are vacuous:
+     *  - a spy whose `unwrap()` returns its **delegate** is discarded at construction — the wrapper's
+     *    constructor stores `wrappedIterable.unwrap()`, so the field would become the delegate, the
+     *    spy's `findLinks` would never run and `seen` would stay `null`, passing with the edit
+     *    reverted. Hence `unwrap() = this`.
+     *  - a spy that only watches the `query` getter cannot discriminate once #7 lands in the same
+     *    commit, because the raw `findLinks` then unwraps the operand itself before reading `query` —
+     *    green either way. Hence recording the operand *object* handed down.
+     */
+    @Test
+    fun `wrapper findLinks unwraps its operand`() {
+        withLowLevelTx { tx ->
+            val raw = YTDBEntityIterable.where(Issue.entityType, tx.getStore(), GremlinBlock.All)
+            val rawOperand = YTDBEntityIterable.where(Sprint.entityType, tx.getStore(), GremlinBlock.All)
+
+            val spy = RecordingIterable(raw)
+            val wrapper = PersistentEntityIterableWrapper(store, spy)
+            // precondition: the spy survived construction (unwrap() returns itself)
+            assertSame(spy, wrapper.unwrap())
+
+            val wrappedOperand = PersistentEntityIterableWrapper(store, rawOperand)
+            wrapper.findLinks(wrappedOperand, "sprint")
+
+            val seen = assertNotNull(spy.seen, "the spy's findLinks was never reached")
+            assertTrue(
+                seen !is PersistentEntityIterableWrapper,
+                "the wrapper handed its operand down still wrapped: ${seen.javaClass.simpleName}"
+            )
+            assertSame(wrappedOperand.unwrap(), seen)
+        }
+    }
+
+    /**
+     * A delegating spy over a real [YTDBEntityIterable] that records the operand it is handed.
+     *
+     * `unwrap()` returns **this** on purpose — see the KDoc of the test that uses it.
+     */
+    private class RecordingIterable(
+        private val delegate: YTDBEntityIterable
+    ) : YTDBEntityIterable by delegate {
+
+        var seen: EntityIterable? = null
+
+        override fun unwrap(): EntityIterable = this
+
+        override fun findLinks(entities: EntityIterable, linkName: String): EntityIterable {
+            seen = entities
+            return delegate.findLinks(entities, linkName)
+        }
+    }
+
+    /** Guards the fixture the other rows depend on. */
+    @Test
+    fun `dataset has issues and sprints`() {
+        withLowLevelTx { tx ->
+            assertTrue(YTDBEntityIterable.where(Issue.entityType, tx.getStore(), GremlinBlock.All).size() > 0)
+            assertEquals(true, YTDBEntityIterable.where(Sprint.entityType, tx.getStore(), GremlinBlock.All).size() > 0)
+        }
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/SnapshotEntityIterableConcatTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/SnapshotEntityIterableConcatTest.kt
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import jetbrains.exodus.database.TransientEntity
+import jetbrains.exodus.entitystore.Entity
+import jetbrains.exodus.entitystore.EntityIterable
+import kotlinx.dnq.link.OnDeletePolicy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * XD-1292 / audit BG18 — `SnapshotEntityIterable.concat` was a copy-paste of the `minus` override
+ * immediately above it (`wrap(original.minus(getOriginal(right)))`), so `a.concat(b)` silently returned
+ * `a \ b`: wrong in **both** directions, dropping every element of `a` that is also in `b` and never
+ * returning any element of `b`.
+ *
+ * The class is `internal` and constructed only from `RemovedTransientEntity.getLinks`
+ * (`RemovedTransientEntity.kt:253-258`), so no test can name it — the fixture must actually delete the
+ * source entity and read the snapshot's links from a flush listener. `dnq-transient-store` has no test
+ * source set, hence `dnq`.
+ *
+ * **`listener.check()` after the transaction is mandatory (TQ23):** `CallbackListener.onFlush` swallows
+ * every `Throwable` the callback raises into `callbackErrors`, and only `check()` rethrows them (and
+ * asserts the callback ran). A version of this test without it is green before *and* after the fix.
+ *
+ * **Both operands stay in the same iterable family**, in two shapes rather than one. No target is removed
+ * in the transaction, so for the three snapshots that *have* targets
+ * `YTDBVertexEntityRemoved.loadMultiple` takes its all-existing branch and yields a `ByIds`
+ * `YTDBEntityIterableImpl`; the fourth, `noTargets`, has no `links` entry at all (the init guard drops
+ * empty id sets, `YTDBVertexEntityRemoved.kt:80-82`) and `loadMultiple` short-circuits to
+ * `YTDBEntityIterable.EMPTY`. Both shapes are YTDB, so every `original.concat(getOriginal(right))` here
+ * is YTDB × YTDB. An `InMemoryEntityIterable` operand would throw before *and* after the fix on the three
+ * `ByIds` rows (`operand()` → `asYTDBIterable()`, and `InMemoryEntityIterable.unwrap()` returns `this`) and
+ * would silently succeed on the `EMPTY` row, since `EMPTY.concat(right)` returns `right` without touching
+ * `operand()` — either way it would make this test look like a Track 04 dependency that does not exist.
+ */
+class SnapshotEntityIterableConcatTest : DBTest() {
+
+    class ConcatTarget(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<ConcatTarget>()
+
+        var name by xdRequiredStringProp()
+    }
+
+    class ConcatSource(entity: Entity) : XdEntity(entity) {
+        companion object : XdNaturalEntityType<ConcatSource>()
+
+        var name by xdRequiredStringProp()
+        val targets by xdLink0_N(ConcatTarget, onTargetDelete = OnDeletePolicy.CLEAR)
+    }
+
+    override fun registerEntityTypes() {
+        super.registerEntityTypes()
+        XdModel.registerNodes(ConcatSource, ConcatTarget)
+    }
+
+    private fun EntityIterable.names() = map { it.getProperty("name") as String }
+
+    @Test
+    fun `snapshot concat concatenates instead of subtracting`() {
+        val listener = CallbackListener()
+        store.addListener(listener)
+
+        lateinit var overlapLeft: ConcatSource
+        lateinit var overlapRight: ConcatSource
+        lateinit var disjoint: ConcatSource
+        lateinit var noTargets: ConcatSource
+
+        store.transactional {
+            val t1 = ConcatTarget.new { name = "t1" }
+            val t2 = ConcatTarget.new { name = "t2" }
+            val t3 = ConcatTarget.new { name = "t3" }
+            val t4 = ConcatTarget.new { name = "t4" }
+
+            overlapLeft = ConcatSource.new { name = "left"; targets.add(t1); targets.add(t2) }
+            overlapRight = ConcatSource.new { name = "right"; targets.add(t2); targets.add(t3) }
+            disjoint = ConcatSource.new { name = "disjoint"; targets.add(t4) }
+            noTargets = ConcatSource.new { name = "noTargets" }
+        }
+
+        listener.onFlush { changes ->
+            fun snapshotOf(source: ConcatSource): TransientEntity {
+                val change = changes.find { it.transientEntity.id == source.entityId }!!
+                return change.snapshotEntity.also { assertTrue(it.isRemoved, "source must be removed") }
+            }
+
+            val left = snapshotOf(overlapLeft).getLinks("targets")
+            val right = snapshotOf(overlapRight).getLinks("targets")
+            val other = snapshotOf(disjoint).getLinks("targets")
+            val empty = snapshotOf(noTargets).getLinks("targets")
+
+            // preconditions on the operands themselves
+            assertEquals(setOf("t1", "t2"), left.names().toSet())
+            assertEquals(setOf("t2", "t3"), right.names().toSet())
+            assertEquals(setOf("t4"), other.names().toSet())
+            assertTrue(empty.isEmpty, "the no-targets snapshot must yield the EMPTY iterable")
+
+            // STRONGEST ROW - overlapping operands: fails in both directions before the fix, where
+            // `left.minus(right)` returned just ["t1"].
+            val overlapping = left.concat(right).names()
+            assertTrue("t2" in overlapping, "an element of the left operand must survive being in the right too")
+            assertTrue("t3" in overlapping, "elements of the right operand must appear at all")
+            assertEquals(setOf("t1", "t2", "t3"), overlapping.toSet())
+            assertEquals(4, overlapping.size, "concat preserves duplicates, unlike union")
+
+            // disjoint operands: ["t1","t2"] before the fix, ["t1","t2","t4"] after
+            assertEquals(setOf("t1", "t2", "t4"), left.concat(other).names().toSet())
+
+            // engine-independent row: original is YTDBEntityIterable.EMPTY, so `EMPTY.minus(b)` was
+            // EMPTY while `EMPTY.concat(b)` is b - no set arithmetic and no operand-family concerns.
+            assertEquals(setOf("t2", "t3"), empty.concat(right).names().toSet())
+        }
+
+        store.transactional {
+            overlapLeft.delete()
+            overlapRight.delete()
+            disjoint.delete()
+            noTargets.delete()
+        }
+        listener.check()
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityIterableClampTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityIterableClampTest.kt
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import com.jetbrains.teamsys.dnq.database.TransientEntityIterable
+import jetbrains.exodus.database.TransientEntity
+import jetbrains.exodus.entitystore.EntityId
+import kotlinx.dnq.events.Foo
+import kotlinx.dnq.events.Goo
+import kotlinx.dnq.query.drop
+import kotlinx.dnq.query.take
+import kotlinx.dnq.query.toList
+import kotlinx.dnq.util.getAddedLinks
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * XD-1292 / audit E1 — `TransientEntityIterable.skip`/`take` delegate to `Sequence.drop`/`Sequence.take`,
+ * both of which open with `require(n >= 0)`, so a negative argument threw `IllegalArgumentException`
+ * where Xodus's `EntityIterableBase` returns the receiver (`skip`) / the empty iterable (`take`).
+ *
+ * E1 is the third provenance of the same B2 defect (the other two are `YTDBEntityIterableImpl` — #10 —
+ * and `dnq-query`'s `AbstractInMemoryEntityIterable` — B2 proper). Without it, DNQ-level `take(-1)` /
+ * `drop(-1)` behaviour would still depend on where the query came from, which is exactly what B2 exists
+ * to prevent.
+ *
+ * `dnq-transient-store` has no test source set, so this lives in `dnq`.
+ *
+ * **Assert contents/emptiness, never identity.** Not because identity could not hold — the clamped
+ * raw-level rows below return the receiver (`skip`) and the shared `YTDBEntityIterable.EMPTY` singleton
+ * (`take`), exactly as the raw YTDB layer does — but because what E1 fixes is the *contract*, i.e. which
+ * elements come back instead of an `IllegalArgumentException`. Contents assertions pin that, and they
+ * keep pinning it if the guards are ever reimplemented to allocate. At the DNQ level identity is not
+ * even available: `XdQuery.take`/`drop` return a freshly wrapped query.
+ */
+class TransientEntityIterableClampTest : DBTest() {
+
+    override fun registerEntityTypes() {
+        XdModel.registerNodes(Foo, Goo)
+    }
+
+    /**
+     * The raw-iterable rows: `getAddedLinks(linkName)` on the underlying [TransientEntity] hands back a
+     * `TransientEntityIterable` directly (`TransientEntityImpl.getAddedLinks`), so `skip`/`take` here are
+     * the edited methods themselves, with no wrapper in between.
+     *
+     * The `0` rows are the boundary controls: widening the existing `number == 0` guards to `number <= 0`
+     * must be bit-identical at `0`, because those guards already returned `this` and
+     * `YTDBEntityIterable.EMPTY`.
+     */
+    @Test
+    fun `TransientEntityIterable clamps negative skip and take`() {
+        val goo = transactional { Goo.new() }
+
+        transactional {
+            (0..2).forEach { i -> goo.content.add(Foo.new { intField = i }) }
+
+            val added = (goo.entity as TransientEntity).getAddedLinks("content")
+            assertTrue(added is TransientEntityIterable, "receiver must be a TransientEntityIterable")
+            val allIds: List<EntityId> = added.map { it.id }
+            assertEquals(3, allIds.size)
+
+            // the defect: both of these threw IllegalArgumentException from `require(n >= 0)`
+            assertTrue(added.take(-1).isEmpty)
+            assertEquals(emptyList(), added.take(-1).map { it.id })
+            assertEquals(allIds, added.skip(-1).map { it.id })
+
+            // `0` boundary controls - unchanged by the widening
+            assertTrue(added.take(0).isEmpty)
+            assertEquals(allIds, added.skip(0).map { it.id })
+        }
+    }
+
+    /**
+     * The public-API row: `XdEntity.getAddedLinks(Goo::content)` inside a flush callback returns an
+     * `XdQuery` over that same anonymous `TransientEntityIterable`, and `XdQuery.take`/`drop` route into
+     * it through `XdQuery.operation` (`toEntityIterable` wraps it in a `PersistentEntityIterableWrapper`,
+     * which *is* a `YTDBEntityIterable`, so the first arm matches and `unwrap()` yields the transient
+     * iterable again). This is the shape a caller actually hits.
+     *
+     * The callback captures instead of asserting, and the captured throwable is asserted `null`
+     * afterwards: a listener that threw would otherwise be indistinguishable from one that never ran,
+     * and the run counter pins that it did run.
+     */
+    @Test
+    fun `negative take and drop on an added-links query do not throw`() {
+        val (f1, f2) = transactional { Pair(Foo.new { intField = 1 }, Foo.new { intField = 2 }) }
+        val goo = transactional { Goo.new() }
+
+        val runs = AtomicInteger(0)
+        val failure = AtomicReference<Throwable?>(null)
+        val all = AtomicReference<List<Int>>(emptyList())
+        val takeNegative = AtomicReference<List<Int>?>(null)
+        val takeZero = AtomicReference<List<Int>?>(null)
+        val dropNegative = AtomicReference<List<Int>?>(null)
+        val dropZero = AtomicReference<List<Int>?>(null)
+
+        Goo.onUpdate { old, _ ->
+            runs.incrementAndGet()
+            try {
+                val query = old.getAddedLinks(Goo::content)
+                all.set(query.toList().map { it.intField })
+                takeNegative.set(query.take(-1).toList().map { it.intField })
+                takeZero.set(query.take(0).toList().map { it.intField })
+                dropNegative.set(query.drop(-1).toList().map { it.intField })
+                dropZero.set(query.drop(0).toList().map { it.intField })
+            } catch (t: Throwable) {
+                failure.set(t)
+            }
+        }
+
+        transactional {
+            goo.content.add(f1)
+            goo.content.add(f2)
+        }
+
+        assertEquals(1, runs.get(), "the update listener must have run")
+        assertNull(failure.get(), "negative take/drop must not throw: ${failure.get()}")
+        assertEquals(listOf(1, 2), all.get().sorted())
+        assertEquals(emptyList(), takeNegative.get())
+        assertEquals(emptyList(), takeZero.get())
+        assertEquals(listOf(1, 2), dropNegative.get()?.sorted())
+        assertEquals(listOf(1, 2), dropZero.get()?.sorted())
+    }
+}

--- a/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityIterableEqualityTest.kt
+++ b/dnq/src/test/kotlin/kotlinx/dnq/TransientEntityIterableEqualityTest.kt
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2006 - 2026 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.dnq
+
+import com.jetbrains.teamsys.dnq.database.TransientEntityIterable
+import jetbrains.exodus.database.TransientEntity
+import jetbrains.exodus.entitystore.Entity
+import kotlinx.dnq.events.Bar
+import kotlinx.dnq.events.Foo
+import kotlinx.dnq.events.Goo
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * XD-1292 / audit #11-B — `TransientEntityIterable.indexOf`/`contains` compared objects
+ * (`values.indexOf` / `values.contains` over a `Set<TransientEntity>`) instead of `EntityId`s.
+ *
+ * This is the most user-visible member of the #11 family: `XdQuery.contains`/`indexOf` route into it
+ * (a `TransientEntityIterable` unwraps to itself, is not a `Collection` and not a
+ * `YTDBEntityIterable`, so `XdQuery.contains` takes the `else` arm → `indexOf(entity) != -1`).
+ *
+ * Argument choice: the **underlying persistent `YTDBEntity`** of a member. That is the natural failing
+ * direction here — `TransientEntityImpl.equals` rejects any non-`TransientEntity` outright, and its
+ * `hashCode` (`id.hashCode() + persistentStore.hashCode()`) differs from `YTDBVertexEntity`'s
+ * (`id.hashCode()`), so the set lookup cannot even land in the right bucket. No mock is needed (and
+ * mockk is not on `dnq`'s test classpath).
+ *
+ * Three guards, all mandatory:
+ *  1. the positive target sits at a **non-zero** index of the iterable's own `toList()`, asserted
+ *     exactly (the index of a `Set`-backed iterable is iteration-order dependent, so it must be
+ *     derived from the iterable, never from insertion order);
+ *  2. a **cross-type collision** control — a `Bar` sharing the target `Foo`'s `localId` (per-class
+ *     `localId` sequences make this the norm) must NOT be found;
+ *  3. an **absent** same-type entity control.
+ */
+class TransientEntityIterableEqualityTest : DBTest() {
+
+    override fun registerEntityTypes() {
+        XdModel.registerNodes(Foo, Goo, Bar)
+    }
+
+    @Test
+    fun `TransientEntityIterable indexOf and contains compare entity ids`() {
+        lateinit var goo: Goo
+        lateinit var foos: List<Foo>
+        lateinit var bars: List<Bar>
+        lateinit var absentFoo: Foo
+        transactional {
+            goo = Goo.new()
+            foos = (0..2).map { Foo.new { intField = it } }
+            // Bars cover localIds 0..4, so whatever localId the target Foo has, a colliding Bar exists.
+            bars = (0..4).map { Bar.new() }
+            absentFoo = Foo.new()
+        }
+
+        transactional {
+            foos.forEach { goo.content.add(it) }
+
+            val added = (goo.entity as TransientEntity).getAddedLinks("content")
+            // Precondition: we are really exercising TransientEntityIterable.
+            assertTrue(added is TransientEntityIterable, "receiver must be a TransientEntityIterable")
+            val members = added.toList()
+            assertEquals(3, members.size)
+
+            // GUARD 1 - positive row on a NON-FIRST element of the iterable's OWN order.
+            val targetIndex = members.size - 1
+            assertTrue(targetIndex > 0, "the positive row must not target index 0")
+            val target = members[targetIndex] as TransientEntity
+            val raw: Entity = target.entity // same EntityId, different Entity implementation
+            assertEquals(target.id, raw.id)
+            assertNotEquals<Class<*>>(target.javaClass, raw.javaClass)
+            assertEquals(targetIndex, added.indexOf(raw))
+            assertTrue(added.contains(raw))
+
+            // GUARD 2 - cross-type collision: same localId, different typeId, must NOT be found.
+            val colliderXd = bars.first { it.entityId.localId == target.id.localId }
+            val collider = colliderXd.entity as TransientEntity
+            assertNotEquals(collider.id.typeId, target.id.typeId, "collider must be of another type")
+            assertEquals(collider.id.localId, target.id.localId, "collider must share the localId")
+            assertFalse(added.contains(collider))
+            assertEquals(-1, added.indexOf(collider))
+            // ... and via its persistent form, the shape a foreign wrapper would arrive in
+            assertFalse(added.contains(collider.entity))
+            assertEquals(-1, added.indexOf(collider.entity))
+
+            // GUARD 3 - an absent entity of the same type.
+            val absent = absentFoo.entity as TransientEntity
+            assertFalse(added.contains(absent))
+            assertEquals(-1, added.indexOf(absent))
+            assertFalse(added.contains(absent.entity))
+            assertEquals(-1, added.indexOf(absent.entity))
+        }
+    }
+
+    /**
+     * BG33 — the rewritten `indexOf`/`contains` read `entity.id` eagerly, where the old
+     * object-equality comparison never invoked the argument's `getId()`.
+     * `TransientEntityImpl.getId()` throws `IllegalStateException("Cannot get wrapped persistent
+     * entity")` when its private `id` field is `null`, so the question is whether the rewrite can turn
+     * a `false` answer into an exception.
+     *
+     * This row pins the answer for the hardest case reachable through the public API: a brand-new,
+     * not-yet-flushed entity, passed both as its `TransientEntity` and as its persistent form, to the
+     * iterable that `XdQuery.contains`/`indexOf` actually routes into. It must be `false` / `-1`, not
+     * a throw.
+     *
+     * Verdict: it does not throw. `TransientEntityImpl.id` is assigned by every constructor before the
+     * object is published (`TransientSessionImpl.createEntity` sets `transientEntity.entity` before
+     * returning; the persistent-entity constructor sets it directly) and is never reset to `null`, so
+     * the `throwWrappedPersistentEntityUndefined()` branch of `getId()` is unreachable for a
+     * normally-constructed entity. The only `getId()` implementations in the repo that always throw
+     * are `UnsupportedOperationEntity` and `FakeTransientEntity`, both `internal` to `dnq` and confined
+     * to the metadata-collecting `filter {}` / `search {}` closures — they are never elements of, nor
+     * arguments to, an `EntityIterable`. Reading the argument's id eagerly is also exactly what the
+     * contract authority does (Xodus `EntityIterableBase.indexOf:219` / `contains:230`).
+     */
+    @Test
+    fun `contains answers false for a brand new unflushed argument`() {
+        val goo = transactional { Goo.new() }
+        transactional {
+            goo.content.add(Foo.new { intField = 1 })
+            goo.content.add(Foo.new { intField = 2 })
+            val added = (goo.entity as TransientEntity).getAddedLinks("content")
+            assertTrue(added is TransientEntityIterable)
+
+            // created in THIS transaction, never flushed, and not linked to goo
+            val fresh = Foo.new { intField = 99 }
+            val freshTransient = fresh.entity as TransientEntity
+            assertTrue(freshTransient.isNew, "precondition: the argument must be an unflushed entity")
+
+            assertFalse(added.contains(freshTransient))
+            assertEquals(-1, added.indexOf(freshTransient))
+            assertFalse(added.contains(freshTransient.entity))
+            assertEquals(-1, added.indexOf(freshTransient.entity))
+        }
+    }
+}


### PR DESCRIPTION
Fixes [XD-1292](https://youtrack.jetbrains.com/issue/XD-1292). Carve-out from XD-1285, whose core `findLinks` receiver fix already landed on `adopt-youtrackdb` as `4fb16a74`; this is the contract-conformance remainder found while verifying it.

The YouTrackDB `EntityIterable`/`EntityIterator` family diverged from the Xodus contracts in three independent ways, several of them silent wrong results rather than failures. One commit per family, each independently green, each followed by an empty track-boundary marker.

### `XD-1292 Restore the Xodus EntityIterator and membership contracts`

- `EntityIterator.skip(n)` returned `true` unconditionally instead of `hasNext()` — at **four** iterators: `YTDBEntityIterator`, `PersistentEntityIteratorWrapper`, `dnq-query`'s `InMemoryEntityIterator` and the anonymous one in `AddedOrRemovedLinksFromSetTransientEntityIterable`. Fixing only the first would have been invisible through the iterator DNQ actually hands out.
- The anonymous iterator in `YTDBVertexEntityIterable` advanced by exactly **one** element for any `n`, because the single `next()` sat in a trailing `.also`; `getLast()` was built on it, so it returned element 1 for size ≥ 2 and threw for size 1.
- `contains`/`indexOf` compared with `Entity.equals` instead of by `EntityId`, so equal ids in different wrapper types missed — at three iterables. Every test carries a same-`localId`-different-type negative control, since per-class local ids collide.
- Two `dispose()` implementations returned `true` while `shouldBeDisposed()` was `false` and nothing was released.

### `XD-1292 Normalise the operand of the YouTrackDB iterable operators`

- The four binary set operators and `findLinks` cast the right operand without `unwrap()`ing it first, so an operand that exposes its query form only through `unwrap()` was rejected outright instead of being combined.
- The `=== EMPTY` short-circuits in those same operators tested the raw argument, so a wrapper around `EMPTY` slipped past and then dereferenced `EMPTY.query`, which is `unsupported`.
- One private `operand()` helper now carries the normalisation for all five raw sites and runs *before* the identity guard. Two more sites joined: `PersistentEntityIterableWrapper.findLinks` (the only operand-taking operator in that class without an `unwrap()`) and the single `YTDBStoreTransactionImpl.findLinks` overload the public session API can reach.

### `XD-1292 Clamp negative take/skip and repair the remaining iterable contracts`

- A negative argument to `take`/`skip` threw instead of clamping, and threw *differently* depending on how the query had been built (YouTrackDB's `require` guards, Kotlin's `Iterable.take`, `Sequence.drop`/`take`). All three provenances now follow Xodus: receiver for `skip(n <= 0)`, empty iterable for `take(n <= 0)`. Negatives only — every `== 0` path is bit-identical to before.
- `SnapshotEntityIterable.concat` was a copy of the `minus` override directly above it, so `a.concat(b)` returned `a \ b` — wrong in both directions, on the snapshot view of a removed entity's links.
- The unreachable `GremlinBlock.Reverse` branch in `GremlinQuery.then` is deleted with the `SortBy.reverseOrder()` it solely called; `ReversedOrder` stays (five live referents).

### Verification

Every edited production site is pinned by a test that **fails when that edit alone is reverted** — established empirically per site, not by inspection. The one deliberate exception is the dead `Reverse` branch: unreachable code cannot fail a behavioural test, so its oracle is compilation plus the byte-identical `checkGremlin` expectations and order assertions of `iterable sort and reverse`.

Full build on the final tree: **204 classes / 1462 tests / 0 failures / 0 errors / 13 pre-existing `@Ignore` skips**. No whole-suite baseline was ever recorded for the base commit, so the regression evidence is a measured 31-class attribution subset that covers every edited file: **536 tests at `51f57cb9`, 547 here, 0 failures on both**, and the 13 skips are the same pre-existing `@Ignore`s, named and confirmed one by one. Every delta is an addition; nothing previously passing changed.

Test placement is forced by the module layout: `dnq-transient-store` has no test source set, and `SnapshotEntityIterable` is `internal` and constructed only from `RemovedTransientEntity`, so its pin goes through a removed entity's snapshot links inside a flush listener, from `dnq`.

### Known-remaining, deliberately out of scope

The six unreachable `sort*` operand casts in `YTDBStoreTransactionImpl`; `YTDBVertexEntityIterable.asQueryIterable()`'s hardcoded `polymorphic = true` (no channel exists to thread the receiver's flag through it); the repeated-`Dedup` collapse in `GremlinQuery.Order.of`, which costs query fusion rather than correctness and would drag the shared optimiser guards into scope.
